### PR TITLE
Add Python mining prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/helix/miner.py
+++ b/helix/miner.py
@@ -1,0 +1,35 @@
+import hashlib
+import os
+import random
+from typing import Optional
+
+
+def truncate_hash(data: bytes, length: int) -> bytes:
+    """Return the first `length` bytes of SHA256(data)."""
+    return hashlib.sha256(data).digest()[:length]
+
+
+def generate_microblock(seed: bytes) -> bytes:
+    """Return microblock for a given seed using G(s) = Truncate_N(H(s || len(s)))."""
+    length = len(seed)
+    input_data = seed + length.to_bytes(4, "big")
+    return hashlib.sha256(input_data).digest()
+
+
+def find_seed(target: bytes, max_seed_len: int = 32, *, attempts: int = 1_000_000) -> Optional[bytes]:
+    """Search for a seed that generates `target` when truncated to len(target)."""
+    target_len = len(target)
+    for _ in range(attempts):
+        seed_len = random.randint(1, max_seed_len)
+        seed = os.urandom(seed_len)
+        candidate = generate_microblock(seed)[:target_len]
+        if candidate == target:
+            return seed
+    return None
+
+
+__all__ = [
+    "truncate_hash",
+    "generate_microblock",
+    "find_seed",
+]

--- a/mine.py
+++ b/mine.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Example miner for Helix microblocks."""
+
+import argparse
+import os
+
+from helix.miner import find_seed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Mine a seed for a target microblock.")
+    parser.add_argument("target", help="Hex-encoded target microblock")
+    parser.add_argument("--max-seed", type=int, default=16, help="Maximum seed length to try")
+    parser.add_argument("--attempts", type=int, default=1_000_000, help="Maximum attempts")
+    args = parser.parse_args()
+
+    target_bytes = bytes.fromhex(args.target)
+    seed = find_seed(target_bytes, max_seed_len=args.max_seed, attempts=args.attempts)
+
+    if seed is not None:
+        print(f"Found seed: {seed.hex()}")
+    else:
+        print("No seed found in given attempts")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add initial Python module for Helix mining
- provide example CLI for searching for microblock seeds
- ignore Python cache files

## Testing
- `python3 -m py_compile helix/miner.py mine.py`


------
https://chatgpt.com/codex/tasks/task_e_684ca46163c8832988b4e9d216c445c4