### PR TITLE
Add Ed25519 signing utilities

### DIFF
--- a/helix/helix_node.py
+++ b/helix/helix_node.py
@@ -1,0 +1,41 @@
+"""Simplified Helix node that verifies and mines events."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .event_manager import mark_mined
+from .signature_utils import verify_signature
+
+
+def verify_originator_signature(event: Dict[str, Any]) -> bool:
+    """Return ``True`` if the event header signature is valid."""
+    header = event.get("header", {}).copy()
+    sig = header.pop("originator_sig", None)
+    pub = header.pop("originator_pub", None)
+    if not sig or not pub:
+        return False
+    return verify_signature(repr(header).encode("utf-8"), sig, pub)
+
+
+def mine_event(event: Dict[str, Any]) -> None:
+    """Verify ``event`` and mark all microblocks as mined."""
+    if not verify_originator_signature(event):
+        raise ValueError("Invalid originator signature")
+
+    for i in range(len(event["microblocks"])):
+        mark_mined(event, i)
+
+
+__all__ = ["verify_originator_signature", "mine_event"]
+
+
+if __name__ == "__main__":
+    import json
+    from .event_manager import create_event
+
+    event = create_event("demo", keyfile=None)
+    try:
+        mine_event(event)
+    except ValueError as exc:
+        print(exc)
+    print(json.dumps(event, indent=2))

--- a/helix/signature_utils.py
+++ b/helix/signature_utils.py
@@ -1,0 +1,80 @@
+"""Utilities for generating and verifying digital signatures using Ed25519."""
+
+from __future__ import annotations
+
+import base64
+from typing import Tuple
+
+from nacl import signing
+
+
+def generate_keypair() -> Tuple[str, str]:
+    """Generate a new Ed25519 keypair.
+
+    Returns a tuple of ``(public_key, private_key)`` where both values are
+    base64-encoded strings.
+    """
+    private_key = signing.SigningKey.generate()
+    public_key = private_key.verify_key
+    priv_b64 = base64.b64encode(private_key.encode()).decode("ascii")
+    pub_b64 = base64.b64encode(public_key.encode()).decode("ascii")
+    return pub_b64, priv_b64
+
+
+def sign_data(data: bytes, private_key: str) -> str:
+    """Return a base64 signature for ``data`` using ``private_key``."""
+    key_bytes = base64.b64decode(private_key)
+    signing_key = signing.SigningKey(key_bytes)
+    signed = signing_key.sign(data)
+    return base64.b64encode(signed.signature).decode("ascii")
+
+
+def verify_signature(data: bytes, signature: str, public_key: str) -> bool:
+    """Verify that ``signature`` matches ``data`` for ``public_key``."""
+    sig_bytes = base64.b64decode(signature)
+    key_bytes = base64.b64decode(public_key)
+    verify_key = signing.VerifyKey(key_bytes)
+    try:
+        verify_key.verify(data, sig_bytes)
+        return True
+    except Exception:
+        return False
+
+
+def save_keys(filename: str, pub: str, priv: str) -> None:
+    """Save base64-encoded ``pub`` and ``priv`` keys to ``filename``."""
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(f"{pub}\n{priv}\n")
+
+
+def load_keys(filename: str) -> Tuple[str, str]:
+    """Load ``(public_key, private_key)`` from ``filename``."""
+    with open(filename, "r", encoding="utf-8") as f:
+        pub = f.readline().strip()
+        priv = f.readline().strip()
+    return pub, priv
+
+__all__ = [
+    "generate_keypair",
+    "sign_data",
+    "verify_signature",
+    "save_keys",
+    "load_keys",
+]
+
+
+
+def main() -> None:
+    """Demonstrate key generation, signing and verification."""
+    pub, priv = generate_keypair()
+    statement = b"Helix signature demo"
+    signature = sign_data(statement, priv)
+    print("Public key:", pub)
+    print("Private key:", priv)
+    print("Signature:", signature)
+    valid = verify_signature(statement, signature, pub)
+    print("Signature valid:", valid)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `signature_utils` module for key generation, signing, verification and key storage
- sign event headers in `event_manager`
- verify originator signature before mining in new `helix_node`

## Testing
- `python3 -m py_compile helix/*.py`
- `python3 helix/signature_utils.py` *(fails: ModuleNotFoundError: No module named 'nacl')*
- `pip install pynacl` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684cd02b541883299f555b57f018c5d8