### PR TITLE
Add wallet module and extra unit tests

### DIFF
--- a/helix/wallet.py
+++ b/helix/wallet.py
@@ -1,0 +1,26 @@
+class Wallet:
+    """Simple HLX wallet for tests."""
+
+    def __init__(self, balance: int = 0) -> None:
+        if balance < 0:
+            raise ValueError("balance must be non-negative")
+        self._balance = balance
+
+    @property
+    def balance(self) -> int:
+        return self._balance
+
+    def deposit(self, amount: int) -> None:
+        if amount < 0:
+            raise ValueError("amount must be non-negative")
+        self._balance += amount
+
+    def withdraw(self, amount: int) -> None:
+        if amount < 0:
+            raise ValueError("amount must be non-negative")
+        if amount > self._balance:
+            raise ValueError("insufficient funds")
+        self._balance -= amount
+
+__all__ = ["Wallet"]
+

--- a/tests/test_betting_interface.py
+++ b/tests/test_betting_interface.py
@@ -1,0 +1,31 @@
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import betting_interface as bi
+from helix import event_manager as em
+from helix import signature_utils as su
+
+
+def test_submit_and_verify_bet(tmp_path):
+    pub, priv = su.generate_keypair()
+    keyfile = tmp_path / "keys.txt"
+    su.save_keys(str(keyfile), pub, priv)
+
+    event = em.create_event("Bet event")
+
+    bet = bi.submit_bet(event["header"]["statement_id"], "YES", 10, str(keyfile))
+    assert bi.verify_bet(bet)
+
+    bi.record_bet(event, bet)
+    assert bet in event["bets"]["YES"]
+
+
+def test_invalid_bet_choice(tmp_path):
+    pub, priv = su.generate_keypair()
+    keyfile = tmp_path / "keys.txt"
+    su.save_keys(str(keyfile), pub, priv)
+
+    with pytest.raises(ValueError):
+        bi.submit_bet("id", "MAYBE", 5, str(keyfile))
+

--- a/tests/test_minihelix.py
+++ b/tests/test_minihelix.py
@@ -1,0 +1,25 @@
+import hashlib
+
+from helix import minihelix as mh
+
+
+def test_G_deterministic():
+    seed = b"abc"
+    N = 4
+    expected = hashlib.sha256(seed + len(seed).to_bytes(1, "big")).digest()[:N]
+    assert mh.G(seed, N) == expected
+
+
+def test_mine_and_verify_seed():
+    seed = b"\x01"
+    block = mh.G(seed, N=1)
+    found = mh.mine_seed(block)
+    assert found == seed
+    assert mh.verify_seed(found, block)
+
+
+def test_verify_seed_false():
+    seed = b"\x02"
+    block = mh.G(seed, N=1)
+    assert not mh.verify_seed(b"\x03", block)
+

--- a/tests/test_statement_submission.py
+++ b/tests/test_statement_submission.py
@@ -1,0 +1,27 @@
+import hashlib
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import event_manager as em
+from helix.helix_node import verify_originator_signature
+from helix import signature_utils as su
+
+
+def test_create_event_with_signature(tmp_path):
+    statement = "Helix test statement"
+    pub, priv = su.generate_keypair()
+    keyfile = tmp_path / "keys.txt"
+    su.save_keys(str(keyfile), pub, priv)
+
+    event = em.create_event(statement, microblock_size=4, keyfile=str(keyfile))
+
+    header_hash = hashlib.sha256(statement.encode("utf-8")).hexdigest()
+    assert event["header"]["statement_id"] == header_hash
+    assert len(event["microblocks"]) == event["header"]["block_count"]
+    assert verify_originator_signature(event)
+
+
+def test_create_event_without_signature():
+    event = em.create_event("No sig", microblock_size=4)
+    assert not verify_originator_signature(event)

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1,0 +1,17 @@
+import pytest
+from helix.wallet import Wallet
+
+
+def test_wallet_deposit_withdraw():
+    w = Wallet(100)
+    w.deposit(50)
+    assert w.balance == 150
+    w.withdraw(70)
+    assert w.balance == 80
+
+
+def test_wallet_withdraw_insufficient():
+    w = Wallet(30)
+    with pytest.raises(ValueError):
+        w.withdraw(40)
+


### PR DESCRIPTION
## Summary
- implement a simple `Wallet` class
- test MiniHelix mining and seed validation
- test statement submission flow
- test betting interface
- test wallet balance updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d8d0d30fc83298f792e1ab7de8b78