### PR TITLE
Add reward flow and integration test

### DIFF
--- a/helix/__init__.py
+++ b/helix/__init__.py
@@ -8,4 +8,5 @@ __all__ = [
     "signature_utils",
     "helix_node",
     "gossip",
+    "ui",
 ]

--- a/helix/ui.py
+++ b/helix/ui.py
@@ -1,0 +1,46 @@
+import json
+import threading
+from typing import Optional
+
+from .betting_interface import submit_bet, record_bet
+from .helix_node import HelixNode, GossipMessageType
+
+
+def run_cli(node: HelixNode, *, keyfile: Optional[str] = None) -> None:
+    """Simple interactive CLI for a :class:`HelixNode`."""
+
+    threading.Thread(target=node._message_loop, daemon=True).start()
+    while True:
+        print("\nHelix CLI")
+        print("1. Submit statement")
+        print("2. Submit bet")
+        print("3. Show balances")
+        print("4. Quit")
+        choice = input("Select: ").strip()
+        if choice == "1":
+            statement = input("Statement: ")
+            event = node.create_event(statement)
+            evt_id = event["header"]["statement_id"]
+            node.events[evt_id] = event
+            node.save_state()
+            node.send_message({"type": GossipMessageType.NEW_STATEMENT, "event": event})
+            threading.Thread(target=node.mine_event, args=(event,)).start()
+        elif choice == "2":
+            evt_id = input("Event ID: ")
+            bet_choice = input("Bet YES/NO: ").strip().upper()
+            amount = int(input("Amount: "))
+            if keyfile is None:
+                keyfile = input("Keyfile path: ")
+            bet = submit_bet(evt_id, bet_choice, amount, keyfile)
+            if evt_id in node.events:
+                record_bet(node.events[evt_id], bet)
+            else:
+                print("Unknown event")
+        elif choice == "3":
+            print(json.dumps(node.balances, indent=2))
+        elif choice == "4":
+            break
+        else:
+            print("Invalid choice")
+
+__all__ = ["run_cli"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,57 @@
+import json
+import threading
+import time
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix.helix_node import HelixNode, GossipMessageType, simulate_mining, find_seed, verify_seed
+from helix.gossip import LocalGossipNetwork
+
+
+def test_full_lifecycle(tmp_path, monkeypatch):
+    network = LocalGossipNetwork()
+    node_a = HelixNode(events_dir=str(tmp_path / "a_events"), balances_file=str(tmp_path / "a_bal.json"), node_id="A", network=network, microblock_size=2)
+    node_b = HelixNode(events_dir=str(tmp_path / "b_events"), balances_file=str(tmp_path / "b_bal.json"), node_id="B", network=network, microblock_size=2)
+
+    # speed up mining
+    monkeypatch.setattr("helix.helix_node.simulate_mining", lambda idx: None)
+    monkeypatch.setattr("helix.helix_node.find_seed", lambda target, attempts=10000: b"x")
+    monkeypatch.setattr("helix.helix_node.verify_seed", lambda s, t: True)
+
+    t_a = threading.Thread(target=node_a._message_loop, daemon=True)
+    t_b = threading.Thread(target=node_b._message_loop, daemon=True)
+    t_a.start()
+    t_b.start()
+
+    statement = "Integration test"
+    event = node_a.create_event(statement)
+    evt_id = event["header"]["statement_id"]
+    node_a.events[evt_id] = event
+    node_a.save_state()
+    node_a.send_message({"type": GossipMessageType.NEW_STATEMENT, "event": event})
+    node_a.mine_event(event)
+    time.sleep(0.1)
+
+    assert evt_id in node_b.events
+
+    yes_bet = {"event_id": evt_id, "choice": "YES", "amount": 10, "pubkey": "user1"}
+    no_bet = {"event_id": evt_id, "choice": "NO", "amount": 5, "pubkey": "user2"}
+    node_a.events[evt_id]["bets"]["YES"].append(yes_bet)
+    node_b.events[evt_id]["bets"]["YES"].append(yes_bet)
+    node_a.events[evt_id]["bets"]["NO"].append(no_bet)
+    node_b.events[evt_id]["bets"]["NO"].append(no_bet)
+
+    node_a.finalize_event(event)
+    time.sleep(0.1)
+
+    assert node_a.balances == node_b.balances
+
+    with open(node_a.balances_file, "r", encoding="utf-8") as fa:
+        bal_a = json.load(fa)
+    with open(node_b.balances_file, "r", encoding="utf-8") as fb:
+        bal_b = json.load(fb)
+
+    assert bal_a == bal_b
+    assert yes_bet["pubkey"] in bal_a
+


### PR DESCRIPTION
## Summary
- add new optional CLI interface for interacting with a node
- implement `finalize_event` and atomic reward distribution
- broadcast event results and ledger updates via gossip
- add integration test covering full lifecycle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d9d88b6688329a70db0cddc2d4904