### PR TITLE
Introduce TCP gossip transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ Install Python dependencies with:
 pip install -r requirements.txt
 ```
 
+## 🚦 Experimental Networking Layer
+
+The initial prototype linked nodes using the in-memory `LocalGossipNetwork`.
+To run nodes across machines, the new `helix.network` package introduces
+socket-based transports for exchanging JSON gossip messages. This
+architecture is designed to evolve toward peer discovery, message routing,
+and optional encryption.
+
 ## 🤝 Get Involved
 
 We're seeking contributors in:

--- a/helix/network/__init__.py
+++ b/helix/network/__init__.py
@@ -1,0 +1,8 @@
+"""Network transports for gossip communication."""
+
+from .transport import GossipTransport
+from .tcp_transport import TCPGossipTransport
+from .peer import Peer
+from .gossip import SocketGossipNetwork
+
+__all__ = ["GossipTransport", "TCPGossipTransport", "Peer", "SocketGossipNetwork"]

--- a/helix/network/gossip.py
+++ b/helix/network/gossip.py
@@ -1,0 +1,34 @@
+"""Networking-based gossip network for Helix nodes."""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from .peer import Peer
+from .transport import GossipTransport
+
+
+class SocketGossipNetwork:
+    """Peer-to-peer gossip network using a :class:`GossipTransport`."""
+
+    def __init__(self, transport: GossipTransport) -> None:
+        self.transport = transport
+        self._peers: dict[str, Peer] = {}
+
+    def register(self, node_id: str, peer: Peer) -> None:
+        self._peers[node_id] = peer
+        self.transport.add_peer(peer)
+
+    def send(self, sender_id: str, message: Dict[str, Any]) -> None:
+        for node_id, peer in self._peers.items():
+            if node_id == sender_id:
+                continue
+            self.transport.send(peer, message)
+
+    def receive(self, timeout: float | None = None) -> tuple[str, Dict[str, Any]]:
+        peer, msg = self.transport.receive(timeout)
+        node_id = peer.node_id or ""
+        return node_id, msg
+
+    def close(self) -> None:
+        self.transport.close()

--- a/helix/network/peer.py
+++ b/helix/network/peer.py
@@ -1,0 +1,12 @@
+"""Information about peers for network communication."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Peer:
+    """Represents a remote Helix node."""
+
+    host: str
+    port: int
+    node_id: str | None = None

--- a/helix/network/tcp_transport.py
+++ b/helix/network/tcp_transport.py
@@ -1,0 +1,67 @@
+"""Simple TCP-based gossip transport."""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import queue
+from typing import Dict, Any, Optional
+
+from .peer import Peer
+from .transport import GossipTransport
+
+
+class TCPGossipTransport(GossipTransport):
+    """TCP transport using a dedicated listen socket."""
+
+    def __init__(self, host: str = "0.0.0.0", port: int = 0) -> None:
+        self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server.bind((host, port))
+        self.host, self.port = self._server.getsockname()
+        self._server.listen()
+        self._peers: list[Peer] = []
+        self._recv_queue: "queue.Queue[tuple[Peer, Dict[str, Any]]]" = queue.Queue()
+        self._running = True
+        threading.Thread(target=self._accept_loop, daemon=True).start()
+
+    def _accept_loop(self) -> None:
+        while self._running:
+            try:
+                conn, addr = self._server.accept()
+                threading.Thread(target=self._client_loop, args=(conn, addr), daemon=True).start()
+            except OSError:
+                break
+
+    def _client_loop(self, conn: socket.socket, addr: tuple[str, int]) -> None:
+        with conn:
+            data = conn.recv(65536)
+            if not data:
+                return
+            try:
+                msg = json.loads(data.decode("utf-8"))
+            except json.JSONDecodeError:
+                return
+            peer = Peer(addr[0], addr[1])
+            self._recv_queue.put((peer, msg))
+
+    def send(self, peer: Peer, message: Dict[str, Any]) -> None:
+        data = json.dumps(message).encode("utf-8")
+        with socket.create_connection((peer.host, peer.port)) as sock:
+            sock.sendall(data)
+
+    def receive(self, timeout: Optional[float] = None) -> tuple[Peer, Dict[str, Any]]:
+        return self._recv_queue.get(timeout=timeout)
+
+    def add_peer(self, peer: Peer) -> None:
+        if peer not in self._peers:
+            self._peers.append(peer)
+
+    def close(self) -> None:
+        self._running = False
+        try:
+            self._server.close()
+        finally:
+            pass
+

--- a/helix/network/transport.py
+++ b/helix/network/transport.py
@@ -1,0 +1,26 @@
+"""Abstract base classes for network transports."""
+
+from __future__ import annotations
+
+import abc
+from typing import Dict, Any
+
+
+class GossipTransport(abc.ABC):
+    """Base API for sending gossip messages between nodes."""
+
+    @abc.abstractmethod
+    def send(self, peer: "Peer", message: Dict[str, Any]) -> None:
+        """Send a message to ``peer``."""
+
+    @abc.abstractmethod
+    def receive(self, timeout: float | None = None) -> tuple["Peer", Dict[str, Any]]:
+        """Wait for the next incoming message."""
+
+    @abc.abstractmethod
+    def add_peer(self, peer: "Peer") -> None:
+        """Register a new peer with this transport."""
+
+    @abc.abstractmethod
+    def close(self) -> None:
+        """Shut down the transport and release resources."""

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,0 +1,14 @@
+import pytest
+
+from helix.network import TCPGossipTransport, SocketGossipNetwork, Peer
+
+
+def test_tcp_transport_loopback():
+    transport = TCPGossipTransport(host="127.0.0.1", port=0)
+    peer = Peer("127.0.0.1", transport.port)
+    transport.add_peer(peer)
+    transport.send(peer, {"msg": "hello"})
+    recv_peer, msg = transport.receive(timeout=1)
+    assert msg == {"msg": "hello"}
+    transport.close()
+


### PR DESCRIPTION
## Summary
- add networking subpackage with pluggable transports
- implement a basic TCP-based gossip transport
- describe the new feature in the README
- add tests for the TCP transport

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684db4ee8a848329aca7134ed7317364