### PR TITLE
Implement statement registry

### DIFF
--- a/helix/__init__.py
+++ b/helix/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "signature_utils",
     "helix_node",
     "cli",
+    "statement_registry",
     "gossip",
     "peer_discovery",
     "ui",

--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -15,7 +15,10 @@ import hashlib
 import math
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from .statement_registry import StatementRegistry
 
 from .signature_utils import load_keys, sign_data
 
@@ -67,6 +70,7 @@ def create_event(
     microblock_size: int = DEFAULT_MICROBLOCK_SIZE,
     *,
     keyfile: str | None = None,
+    registry: "StatementRegistry" | None = None,
 ) -> Dict[str, Any]:
     """Create an event dictionary for ``statement`` and optionally sign it."""
 
@@ -74,6 +78,8 @@ def create_event(
         statement, microblock_size
     )
     statement_id = sha256(statement.encode("utf-8"))
+    if registry is not None:
+        registry.check_and_add(statement)
 
     header = {
         "statement_id": statement_id,

--- a/helix/statement_registry.py
+++ b/helix/statement_registry.py
@@ -1,0 +1,53 @@
+import json
+import os
+from typing import Iterable, Set
+
+from . import event_manager
+
+
+class StatementRegistry:
+    """Registry of statement hashes to prevent exact duplicates."""
+
+    def __init__(self, hashes: Iterable[str] | None = None) -> None:
+        self._hashes: Set[str] = set(hashes or [])
+
+    def _hash_statement(self, statement: str) -> str:
+        return event_manager.sha256(statement.encode("utf-8"))
+
+    def check_and_add(self, statement: str) -> None:
+        """Add ``statement`` if not already present else raise ``ValueError``."""
+        h = self._hash_statement(statement)
+        if h in self._hashes:
+            raise ValueError("Duplicate statement")
+        self._hashes.add(h)
+
+    def has(self, statement: str) -> bool:
+        return self._hash_statement(statement) in self._hashes
+
+    def load(self, path: str) -> None:
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+                if isinstance(data, list):
+                    self._hashes = set(str(x) for x in data)
+
+    def save(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(sorted(self._hashes), fh, indent=2)
+
+    def rebuild_from_events(self, events_dir: str) -> None:
+        if not os.path.isdir(events_dir):
+            return
+        for fname in os.listdir(events_dir):
+            if not fname.endswith(".json"):
+                continue
+            try:
+                event = event_manager.load_event(os.path.join(events_dir, fname))
+            except Exception:
+                continue
+            if event.get("is_closed"):
+                h = event["header"]["statement_id"]
+                self._hashes.add(h)
+
+
+__all__ = ["StatementRegistry"]

--- a/tests/test_statement_registry.py
+++ b/tests/test_statement_registry.py
@@ -1,0 +1,42 @@
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import event_manager
+from helix.statement_registry import StatementRegistry
+
+
+def test_reject_duplicate_statement():
+    registry = StatementRegistry()
+    event_manager.create_event("Unique statement", registry=registry)
+    with pytest.raises(ValueError):
+        event_manager.create_event("Unique statement", registry=registry)
+
+    # different text allowed
+    event_manager.create_event("unique statement", registry=registry)
+
+
+def test_registry_persistence(tmp_path):
+    registry = StatementRegistry()
+    event_manager.create_event("Persisted", registry=registry)
+    reg_file = tmp_path / "registry.json"
+    registry.save(str(reg_file))
+
+    new_reg = StatementRegistry()
+    new_reg.load(str(reg_file))
+    with pytest.raises(ValueError):
+        event_manager.create_event("Persisted", registry=new_reg)
+
+
+def test_rebuild_from_events(tmp_path):
+    registry = StatementRegistry()
+    event = event_manager.create_event("Finalized", registry=registry)
+    # close the event
+    for i in range(event["header"]["block_count"]):
+        event_manager.mark_mined(event, i)
+    event_manager.save_event(event, str(tmp_path))
+
+    new_reg = StatementRegistry()
+    new_reg.rebuild_from_events(str(tmp_path))
+    with pytest.raises(ValueError):
+        event_manager.create_event("Finalized", registry=new_reg)


### PR DESCRIPTION
## Summary
- add StatementRegistry for exact-match deduplication
- hook statement creation to registry checks
- expose the new module in `helix.__init__`
- test persistence and rebuild of the registry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684db6fa90908329bc2dd9c7e7729eb7