### PR TITLE
Persist wallet keypairs

### DIFF
--- a/helix/signature_utils.py
+++ b/helix/signature_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 from typing import Tuple
+from pathlib import Path
 
 from nacl import signing
 
@@ -55,12 +56,23 @@ def load_keys(filename: str) -> Tuple[str, str]:
     return pub, priv
 
 
+def load_or_create_keys(filename: str) -> Tuple[str, str]:
+    """Return keys from ``filename`` or generate and save new ones."""
+    path = Path(filename)
+    if path.exists():
+        return load_keys(filename)
+    pub, priv = generate_keypair()
+    save_keys(filename, pub, priv)
+    return pub, priv
+
+
 __all__ = [
     "generate_keypair",
     "sign_data",
     "verify_signature",
     "save_keys",
     "load_keys",
+    "load_or_create_keys",
 ]
 
 

--- a/helix/wallet_cli.py
+++ b/helix/wallet_cli.py
@@ -9,9 +9,14 @@ from .ledger import load_balances
 
 
 def cmd_wallet_create(args: argparse.Namespace) -> None:
-    pub, priv = signature_utils.generate_keypair()
-    signature_utils.save_keys(args.keyfile, pub, priv)
-    print(f"Created new keypair at {args.keyfile}")
+    key_path = Path(args.keyfile)
+    if key_path.exists():
+        pub, priv = signature_utils.load_keys(str(key_path))
+        print(f"Using existing keypair at {args.keyfile}")
+    else:
+        pub, priv = signature_utils.generate_keypair()
+        signature_utils.save_keys(str(key_path), pub, priv)
+        print(f"Created new keypair at {args.keyfile}")
     print(f"Public key: {pub}")
 
 

--- a/tests/test_signature_utils.py
+++ b/tests/test_signature_utils.py
@@ -18,3 +18,11 @@ def test_save_and_load_keys(tmp_path):
     su.save_keys(str(keyfile), pub, priv)
     loaded_pub, loaded_priv = su.load_keys(str(keyfile))
     assert (loaded_pub, loaded_priv) == (pub, priv)
+
+
+def test_load_or_create_keys(tmp_path):
+    keyfile = tmp_path / "wallet.txt"
+    pub1, priv1 = su.load_or_create_keys(str(keyfile))
+    assert keyfile.exists()
+    pub2, priv2 = su.load_or_create_keys(str(keyfile))
+    assert (pub1, priv1) == (pub2, priv2)


### PR DESCRIPTION
## Summary
- generate Ed25519 wallet keys if needed and store on disk
- load existing keys when available
- add helper to load or create keys
- unit test for new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684db84fb5e4832994175eba2b2cdc2e