### PR TITLE
Add simulation test and implement HelixNode mining features

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import pytest
+
+# Ensure project root on path when running directly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import importlib
+
+pytest.importorskip("nacl")
+
+
+def test_module_imports():
+    importlib.import_module('helix.event_manager')
+    importlib.import_module('helix.helix_node')
+    importlib.import_module('helix.minihelix')
+    importlib.import_module('helix.betting_interface')
+    importlib.import_module('helix.signature_utils')
+

--- a/tests/test_simulate_mining.py
+++ b/tests/test_simulate_mining.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import pytest
+
+# ensure project root is on path for direct execution
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+pytest.importorskip("nacl")
+
+from helix import event_manager, minihelix
+
+
+def test_simulated_mining():
+    statement = "abc"
+    event = event_manager.create_event(statement, microblock_size=3)
+    for idx, block in enumerate(event["microblocks"]):
+        seed = minihelix.mine_seed(block, max_attempts=100000)
+        assert seed is not None
+        assert minihelix.verify_seed(seed, block)
+        event["seeds"][idx] = seed
+        event_manager.mark_mined(event, idx)
+    assert event["is_closed"]
+    final = event_manager.reassemble_microblocks(event["microblocks"])
+    assert final == statement


### PR DESCRIPTION
## Summary
- fix imports in `helix_node` to support running as a script
- implement `simulate_mining`, `mine_event`, `_message_loop` and `finalize_event`
- expose common symbols via `__all__`
- add tests for importing modules and for a short mining simulation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dbe677f848329b0e3f43805c11a47