### PR TITLE
Implement basic peer discovery with PING/PONG

### DIFF
--- a/helix/gossip.py
+++ b/helix/gossip.py
@@ -29,19 +29,45 @@ class LocalGossipNetwork:
 class GossipNode:
     """Participant in a :class:`LocalGossipNetwork`."""
 
+    PRESENCE_PING = "PING"
+    PRESENCE_PONG = "PONG"
+
     def __init__(self, node_id: str, network: LocalGossipNetwork) -> None:
         self.node_id = node_id
         self.network = network
         self._queue: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+        self.known_peers: set[str] = set()
         self.network.register(self)
 
     def send_message(self, message: Dict[str, Any]) -> None:
         """Send ``message`` to all peers on the network."""
         self.network.send(self.node_id, message)
 
+    # ------------------------------------------------------------------
+    # presence handling
+    def broadcast_presence(self) -> None:
+        """Announce this node to all peers."""
+        self.send_message({"type": self.PRESENCE_PING, "sender": self.node_id})
+
+    def _handle_presence(self, message: Dict[str, Any]) -> None:
+        msg_type = message.get("type")
+        sender = message.get("sender")
+        if not sender or sender == self.node_id:
+            return
+        if msg_type == self.PRESENCE_PING:
+            self.known_peers.add(sender)
+            # respond
+            self.send_message(
+                {"type": self.PRESENCE_PONG, "sender": self.node_id}
+            )
+        elif msg_type == self.PRESENCE_PONG:
+            self.known_peers.add(sender)
+
     def receive(self, timeout: float | None = None) -> Dict[str, Any]:
-        """Return the next message for this node."""
-        return self._queue.get(timeout=timeout)
+        """Return the next message for this node and handle presence messages."""
+        msg = self._queue.get(timeout=timeout)
+        self._handle_presence(msg)
+        return msg
 
 
 __all__ = ["LocalGossipNetwork", "GossipNode"]

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -22,3 +22,18 @@ def test_sender_does_not_receive_own_message():
         node_a.receive(timeout=0.1)
     msg = node_b.receive(timeout=1)
     assert msg["type"] == "SEED"
+
+
+def test_presence_ping_pong():
+    network = LocalGossipNetwork()
+    node_a = GossipNode("A", network)
+    node_b = GossipNode("B", network)
+
+    node_a.broadcast_presence()
+    ping = node_b.receive(timeout=1)
+    assert ping["type"] == GossipNode.PRESENCE_PING
+    assert node_b.known_peers == {"A"}
+
+    pong = node_a.receive(timeout=1)
+    assert pong["type"] == GossipNode.PRESENCE_PONG
+    assert node_a.known_peers == {"B"}


### PR DESCRIPTION
## Summary
- extend `GossipNode` with presence message support
- allow nodes to broadcast their presence and update `known_peers`
- add unit test covering the new peer discovery behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dbf071d1883299ed09ec8a287db71