### PR TITLE
Add optional statement normalization

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -12,6 +12,8 @@ padding bytes can be safely trimmed.
 """
 
 import hashlib
+import re
+import string
 import math
 import json
 from pathlib import Path
@@ -25,6 +27,16 @@ from .config import GENESIS_HASH
 
 DEFAULT_MICROBLOCK_SIZE = 8  # bytes
 FINAL_BLOCK_PADDING_BYTE = b"\x00"
+
+
+def normalize_statement(statement: str) -> str:
+    """Return ``statement`` lowercased with collapsed whitespace and without
+    trailing punctuation."""
+
+    s = statement.strip()
+    s = re.sub(r"\s+", " ", s)
+    s = s.rstrip(string.punctuation)
+    return s.lower()
 
 
 def sha256(data: bytes) -> str:
@@ -73,13 +85,20 @@ def create_event(
     parent_id: str = GENESIS_HASH,
     keyfile: str | None = None,
     registry: "StatementRegistry" | None = None,
+    normalize: bool = False,
 ) -> Dict[str, Any]:
-    """Create an event dictionary for ``statement`` and optionally sign it."""
+    """Create an event dictionary for ``statement`` and optionally sign it.
+
+    If ``normalize`` is ``True`` the statement ID is calculated using a
+    normalized version of the statement so that near-duplicates share the same
+    identifier.
+    """
 
     microblocks, block_count, total_len = split_into_microblocks(
         statement, microblock_size
     )
-    statement_id = sha256(statement.encode("utf-8"))
+    hash_input = normalize_statement(statement) if normalize else statement
+    statement_id = sha256(hash_input.encode("utf-8"))
     if registry is not None:
         registry.check_and_add(statement)
 
@@ -149,6 +168,7 @@ __all__ = [
     "FINAL_BLOCK_PADDING_BYTE",
     "split_into_microblocks",
     "reassemble_microblocks",
+    "normalize_statement",
     "create_event",
     "mark_mined",
     "save_event",

--- a/helix/helix_cli.py
+++ b/helix/helix_cli.py
@@ -31,7 +31,7 @@ def cmd_generate_keys(args: argparse.Namespace) -> None:
 
 
 def cmd_submit_statement(args: argparse.Namespace) -> None:
-    event = event_manager.create_event(args.text)
+    event = event_manager.create_event(args.text, normalize=args.normalize)
     for idx, block in enumerate(event["microblocks"]):
         seed = minihelix.mine_seed(block)
         if seed is None or not minihelix.verify_seed(seed, block):
@@ -66,6 +66,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_submit = sub.add_parser("submit-statement", help="Submit a statement")
     p_submit.add_argument("--text", required=True, help="Statement text")
+    p_submit.add_argument(
+        "--normalize",
+        action="store_true",
+        help="Normalize statement before hashing",
+    )
     p_submit.set_defaults(func=cmd_submit_statement)
 
     p_gen = sub.add_parser("generate-keys", help="Generate a keypair")

--- a/helix/statement_registry.py
+++ b/helix/statement_registry.py
@@ -8,11 +8,23 @@ from . import event_manager
 class StatementRegistry:
     """Registry of statement hashes to prevent exact duplicates."""
 
-    def __init__(self, hashes: Iterable[str] | None = None) -> None:
+    def __init__(self, hashes: Iterable[str] | None = None, *, normalize: bool = False) -> None:
+        """Create a new registry.
+
+        If ``normalize`` is ``True`` statements are normalized prior to hashing
+        so that near-duplicates resolve to the same identifier.
+        """
+
         self._hashes: Set[str] = set(hashes or [])
+        self.normalize = normalize
 
     def _hash_statement(self, statement: str) -> str:
-        return event_manager.sha256(statement.encode("utf-8"))
+        text = (
+            event_manager.normalize_statement(statement)
+            if self.normalize
+            else statement
+        )
+        return event_manager.sha256(text.encode("utf-8"))
 
     def check_and_add(self, statement: str) -> None:
         """Add ``statement`` if not already present else raise ``ValueError``."""

--- a/tests/test_statement_registry.py
+++ b/tests/test_statement_registry.py
@@ -40,3 +40,10 @@ def test_rebuild_from_events(tmp_path):
     new_reg.rebuild_from_events(str(tmp_path))
     with pytest.raises(ValueError):
         event_manager.create_event("Finalized", registry=new_reg)
+
+
+def test_normalized_duplicate_detection():
+    registry = StatementRegistry(normalize=True)
+    event_manager.create_event("Aliens exist.", registry=registry, normalize=True)
+    with pytest.raises(ValueError):
+        event_manager.create_event("aliens exist", registry=registry, normalize=True)


### PR DESCRIPTION
## Summary
- add `normalize_statement` helper
- allow `create_event` to normalize before hashing
- support normalized hashing in `StatementRegistry`
- expose CLI flag `--normalize`
- test duplicate detection with normalization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684dbf10bee8832984b602ae44f2c922