### PR TITLE
Add single-node microblock integration test

### DIFF
--- a/tests/test_single_node_microblock.py
+++ b/tests/test_single_node_microblock.py
@@ -1,0 +1,45 @@
+import threading
+import time
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix.helix_node import HelixNode, GossipMessageType, simulate_mining, find_seed, verify_seed
+from helix.gossip import LocalGossipNetwork
+from helix import event_manager
+
+
+def test_single_node_microblock(tmp_path, monkeypatch, capsys):
+    network = LocalGossipNetwork()
+    events_dir = tmp_path / "test_events"
+    node = HelixNode(
+        events_dir=str(events_dir),
+        balances_file=str(tmp_path / "balances.json"),
+        node_id="A",
+        network=network,
+        microblock_size=3,
+    )
+
+    # accelerate mining
+    monkeypatch.setattr("helix.helix_node.simulate_mining", lambda idx: None)
+    monkeypatch.setattr("helix.helix_node.find_seed", lambda target, attempts=10000: b"x")
+    monkeypatch.setattr("helix.helix_node.verify_seed", lambda s, t: True)
+
+    t = threading.Thread(target=node._message_loop, daemon=True)
+    t.start()
+
+    statement = "abc"
+    event = node.create_event(statement)
+    evt_id = event["header"]["statement_id"]
+    node.events[evt_id] = event
+    node.save_state()
+
+    node.send_message({"type": GossipMessageType.NEW_STATEMENT, "event": event})
+    node.mine_event(event)
+    time.sleep(0.1)
+
+    assert event["is_closed"]
+    reassembled = event_manager.reassemble_microblocks(event["microblocks"])
+    assert reassembled == statement
+
+    print("SUCCESS")


### PR DESCRIPTION
## Summary
- add integration test for single HelixNode microblock mining

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684dc2de599c8329a5cae986dda6a23a