### PR TITLE
Add signed statement submission to helix_cli

### DIFF
--- a/helix/helix_cli.py
+++ b/helix/helix_cli.py
@@ -7,6 +7,7 @@ from . import minihelix
 from . import signature_utils
 from . import betting_interface
 from .ledger import load_balances
+from .helix_node import GossipNode, LocalGossipNetwork
 
 EVENTS_DIR = Path("events")
 BALANCES_FILE = Path("balances.json")
@@ -31,17 +32,19 @@ def cmd_generate_keys(args: argparse.Namespace) -> None:
 
 
 def cmd_submit_statement(args: argparse.Namespace) -> None:
-    event = event_manager.create_event(args.text, normalize=args.normalize)
-    for idx, block in enumerate(event["microblocks"]):
-        seed = minihelix.mine_seed(block)
-        if seed is None or not minihelix.verify_seed(seed, block):
-            print(f"Failed to mine microblock {idx}")
-            continue
-        event["seeds"][idx] = seed
-        event_manager.mark_mined(event, idx)
-    path = event_manager.save_event(event, str(EVENTS_DIR))
+    event = event_manager.create_event(
+        args.statement,
+        microblock_size=args.microblock_size,
+        keyfile=args.keyfile,
+        normalize=args.normalize,
+    )
+
+    network = LocalGossipNetwork()
+    node = GossipNode("CLI", network)
+    node.send_message({"type": "NEW_STATEMENT", "event": event})
+
     print(f"Statement ID: {event['header']['statement_id']}")
-    print(f"Saved to {path}")
+    print("Event submitted via gossip")
 
 
 def cmd_show_balance(args: argparse.Namespace) -> None:
@@ -65,7 +68,18 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_submit = sub.add_parser("submit-statement", help="Submit a statement")
-    p_submit.add_argument("--text", required=True, help="Statement text")
+    p_submit.add_argument("statement", help="Statement text")
+    p_submit.add_argument(
+        "--keyfile",
+        required=True,
+        help="File containing originator keys",
+    )
+    p_submit.add_argument(
+        "--microblock-size",
+        type=int,
+        default=4,
+        help="Microblock size in bytes",
+    )
     p_submit.add_argument(
         "--normalize",
         action="store_true",


### PR DESCRIPTION
## Summary
- support signing and gossip submission in `helix_cli`
- allow specifying microblock size when creating an event
- load originator keys from file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc2af29948329b58d8942510f7668