### PR TITLE
Enforce genesis parent validation

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -155,6 +155,16 @@ def save_event(event: Dict[str, Any], directory: str) -> str:
     return str(filename)
 
 
+def validate_parent(event: Dict[str, Any], *, ancestors: set[str] | None = None) -> None:
+    """Raise ``ValueError`` if ``event`` has an unknown ``parent_id``."""
+
+    if ancestors is None:
+        ancestors = {GENESIS_HASH}
+    parent_id = event.get("header", {}).get("parent_id")
+    if parent_id not in ancestors:
+        raise ValueError("invalid parent_id")
+
+
 def load_event(path: str) -> Dict[str, Any]:
     """Load an event from ``path`` and return the event dict."""
     with open(path, "r", encoding="utf-8") as f:
@@ -162,6 +172,7 @@ def load_event(path: str) -> Dict[str, Any]:
     data["microblocks"] = [bytes.fromhex(b) for b in data.get("microblocks", [])]
     if "seeds" in data:
         data["seeds"] = [bytes.fromhex(s) if isinstance(s, str) and s else None for s in data["seeds"]]
+    validate_parent(data)
     return data
 
 
@@ -175,6 +186,7 @@ __all__ = [
     "mark_mined",
     "save_event",
     "load_event",
+    "validate_parent",
 ]
 
 

--- a/tests/test_parent_validation.py
+++ b/tests/test_parent_validation.py
@@ -1,0 +1,22 @@
+import json
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import event_manager as em
+from helix.config import GENESIS_HASH
+
+
+def test_load_event_with_valid_parent(tmp_path):
+    event = em.create_event("valid")
+    path = em.save_event(event, str(tmp_path))
+    loaded = em.load_event(path)
+    assert loaded["header"]["parent_id"] == GENESIS_HASH
+
+
+def test_load_event_invalid_parent(tmp_path):
+    event = em.create_event("bad")
+    event["header"]["parent_id"] = "badparent"
+    path = em.save_event(event, str(tmp_path))
+    with pytest.raises(ValueError):
+        em.load_event(path)


### PR DESCRIPTION
## Summary
- validate event ancestry before accepting events
- fail `load_event()` if parent hash is unknown
- cover parent validation logic with a test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc4e1c8d48329ad23bea909304db4