### PR TITLE
Add reassemble command to CLI

### DIFF
--- a/helix/cli.py
+++ b/helix/cli.py
@@ -79,6 +79,28 @@ def cmd_view_wallet(args: argparse.Namespace) -> None:
     print(json.dumps(balances, indent=2))
 
 
+def cmd_reassemble(args: argparse.Namespace) -> None:
+    """Load an event and print its reconstructed statement."""
+
+    events_dir = Path(args.data_dir) / "events"
+    if args.path is not None:
+        event_path = Path(args.path)
+    else:
+        event_path = events_dir / f"{args.event_id}.json"
+
+    if not event_path.exists():
+        print("Event not found")
+        return
+
+    event = _load_event(event_path)
+    statement = event_manager.reassemble_microblocks(event["microblocks"])
+
+    if statement != event.get("statement"):
+        raise SystemExit("Padding trim verification failed")
+
+    print(statement)
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="helix-cli")
     parser.add_argument("--data-dir", default="data", help="Directory for node data")
@@ -106,6 +128,12 @@ def main(argv: list[str] | None = None) -> None:
 
     p_wallet = sub.add_parser("view-wallet", help="View wallet balances")
     p_wallet.set_defaults(func=cmd_view_wallet)
+
+    p_reassemble = sub.add_parser("reassemble", help="Reassemble an event")
+    group = p_reassemble.add_mutually_exclusive_group(required=True)
+    group.add_argument("--event-id", help="Event identifier")
+    group.add_argument("--path", help="Path to event JSON file")
+    p_reassemble.set_defaults(func=cmd_reassemble)
 
     args = parser.parse_args(argv)
     args.func(args)

--- a/tests/test_cli_reassemble.py
+++ b/tests/test_cli_reassemble.py
@@ -1,0 +1,19 @@
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import cli, event_manager as em
+
+
+def test_cli_reassemble(tmp_path, capsys):
+    event = em.create_event("CLI reassemble test", microblock_size=4)
+    path = em.save_event(event, str(tmp_path / "events"))
+    evt_id = event["header"]["statement_id"]
+
+    cli.main(["--data-dir", str(tmp_path), "reassemble", "--event-id", evt_id])
+    out = capsys.readouterr().out.strip()
+    assert out.endswith("CLI reassemble test")
+
+    cli.main(["reassemble", "--path", path])
+    out = capsys.readouterr().out.strip()
+    assert out.endswith("CLI reassemble test")


### PR DESCRIPTION
## Summary
- add `reassemble` helper to CLI for reading events
- expose a new CLI subcommand to reassemble a statement
- test reassembly CLI action

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc9ff46048329b85e5eb909a3dc41