### PR TITLE
Add nested mining fallback

### DIFF
--- a/helix/helix_node.py
+++ b/helix/helix_node.py
@@ -11,7 +11,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from . import event_manager, minihelix
+from . import event_manager, minihelix, nested_miner
 from .config import GENESIS_HASH
 from .ledger import load_balances, save_balances
 
@@ -158,6 +158,7 @@ class HelixNode(GossipNode):
         network: LocalGossipNetwork | None = None,
         microblock_size: int = event_manager.DEFAULT_MICROBLOCK_SIZE,
         genesis_file: str = "genesis.json",
+        max_nested_depth: int = 3,
     ) -> None:
         if network is None:
             network = LocalGossipNetwork()
@@ -166,6 +167,7 @@ class HelixNode(GossipNode):
         self.balances_file = balances_file
         self.microblock_size = microblock_size
         self.genesis_file = genesis_file
+        self.max_nested_depth = max_nested_depth
         self.genesis = self._load_genesis(genesis_file)
         self.events: Dict[str, Dict[str, Any]] = {}
         self.balances: Dict[str, int] = {}
@@ -216,9 +218,31 @@ class HelixNode(GossipNode):
             if event["seeds"][idx]:
                 continue
             simulate_mining(idx)
+            best_seed: Optional[bytes] = None
+            best_depth = 0
+
             seed = find_seed(block)
             if seed and verify_seed(seed, block):
-                event["seeds"][idx] = seed
+                best_seed = seed
+                best_depth = 1
+
+            for depth in range(2, self.max_nested_depth + 1):
+                if best_seed is not None and best_depth <= depth:
+                    break
+                result = nested_miner.find_nested_seed(block, max_depth=depth)
+                if result:
+                    chain, found_depth = result
+                    candidate = chain[0]
+                    if (
+                        best_seed is None
+                        or found_depth < best_depth
+                        or (found_depth == best_depth and len(candidate) < len(best_seed))
+                    ):
+                        best_seed = candidate
+                        best_depth = found_depth
+
+            if best_seed is not None:
+                event["seeds"][idx] = {"seed": best_seed, "depth": best_depth}
                 event_manager.mark_mined(event, idx)
 
     def finalize_event(self, event: dict) -> None:

--- a/tests/test_nested_mining_node.py
+++ b/tests/test_nested_mining_node.py
@@ -1,0 +1,37 @@
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix.helix_node import HelixNode
+from helix.gossip import LocalGossipNetwork
+from helix import minihelix
+
+
+def test_nested_mining_fallback(tmp_path, monkeypatch):
+    network = LocalGossipNetwork()
+    node = HelixNode(
+        events_dir=str(tmp_path / "events"),
+        balances_file=str(tmp_path / "balances.json"),
+        network=network,
+        microblock_size=2,
+        max_nested_depth=3,
+    )
+
+    # disable real mining
+    monkeypatch.setattr("helix.helix_node.simulate_mining", lambda idx: None)
+    monkeypatch.setattr("helix.helix_node.find_seed", lambda target: None)
+
+    chain = [b"a", minihelix.G(b"a", 2)]
+    monkeypatch.setattr(
+        "helix.helix_node.nested_miner.find_nested_seed",
+        lambda target, max_depth: (chain, 2),
+    )
+
+    event = node.create_event("ab", keyfile=None)
+    evt_id = event["header"]["statement_id"]
+    node.events[evt_id] = event
+
+    node.mine_event(event)
+
+    assert event["is_closed"]
+    assert event["seeds"][0]["depth"] == 2

--- a/tests/test_simulate_mining.py
+++ b/tests/test_simulate_mining.py
@@ -17,7 +17,7 @@ def test_simulated_mining():
         seed = minihelix.mine_seed(block, max_attempts=100000)
         assert seed is not None
         assert minihelix.verify_seed(seed, block)
-        event["seeds"][idx] = seed
+        event["seeds"][idx] = {"seed": seed, "depth": 1}
         event_manager.mark_mined(event, idx)
     assert event["is_closed"]
     final = event_manager.reassemble_microblocks(event["microblocks"])


### PR DESCRIPTION
## Summary
- support nested seed mining up to a configurable depth
- preserve depth metadata in event seeds
- fall back to nested mining when flat search fails
- extend event persistence to handle metadata
- tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dca0a92f88329ad825249edc9926c