### PR TITLE
Add nested seed penalty handling

### DIFF
--- a/tests/test_nesting_penalty.py
+++ b/tests/test_nesting_penalty.py
@@ -1,0 +1,34 @@
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import event_manager
+
+
+def test_accept_mined_seed_replacement():
+    event = event_manager.create_event("abc", microblock_size=3)
+    refund = event_manager.accept_mined_seed(event, 0, b"a", 3)
+    assert refund == 0
+    assert event["seed_depths"][0] == 3
+    assert event["penalties"][0] == 2
+    original_reward = event["rewards"][0]
+
+    refund = event_manager.accept_mined_seed(event, 0, b"a", 2)
+    assert refund > 0
+    assert event["seed_depths"][0] == 2
+    assert event["penalties"][0] == 1
+    assert event["refunds"][0] == refund
+    assert event["rewards"][0] < original_reward
+
+
+def test_accept_mined_seed_conditions():
+    event = event_manager.create_event("abc", microblock_size=3)
+    event_manager.accept_mined_seed(event, 0, b"a", 2)
+    # different length should not replace
+    refund = event_manager.accept_mined_seed(event, 0, b"bb", 1)
+    assert refund == 0
+    assert event["seeds"][0] == b"a"
+    # higher depth should not replace
+    refund = event_manager.accept_mined_seed(event, 0, b"c", 3)
+    assert refund == 0
+    assert event["seed_depths"][0] == 2


### PR DESCRIPTION
## Summary
- add base reward constants and helper functions in `event_manager`
- store depth, penalty, reward and refund for each block
- allow replacement of mined seeds when new ones have less nesting
- record refund amount for replaced seeds
- test the replacement logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dca136ab0832986d4d0e841552150