### PR TITLE
Remove statement normalization

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -1,6 +1,4 @@
 import hashlib
-import re
-import string
 import math
 import json
 from pathlib import Path
@@ -25,13 +23,6 @@ def nesting_penalty(depth: int) -> int:
 
 def reward_for_depth(depth: int) -> float:
     return BASE_REWARD / depth
-
-
-def normalize_statement(statement: str) -> str:
-    s = statement.strip()
-    s = re.sub(r"\s+", " ", s)
-    s = s.rstrip(string.punctuation)
-    return s.lower()
 
 
 def sha256(data: bytes) -> str:
@@ -69,13 +60,11 @@ def create_event(
     parent_id: str = GENESIS_HASH,
     keyfile: str | None = None,
     registry: "StatementRegistry" | None = None,
-    normalize: bool = False,
 ) -> Dict[str, Any]:
     microblocks, block_count, total_len = split_into_microblocks(
         statement, microblock_size
     )
-    hash_input = normalize_statement(statement) if normalize else statement
-    statement_id = sha256(hash_input.encode("utf-8"))
+    statement_id = sha256(statement.encode("utf-8"))
     if registry is not None:
         registry.check_and_add(statement)
 
@@ -185,7 +174,6 @@ __all__ = [
     "FINAL_BLOCK_PADDING_BYTE",
     "split_into_microblocks",
     "reassemble_microblocks",
-    "normalize_statement",
     "create_event",
     "mark_mined",
     "nesting_penalty",

--- a/helix/helix_cli.py
+++ b/helix/helix_cli.py
@@ -37,7 +37,6 @@ def cmd_submit_statement(args: argparse.Namespace) -> None:
         args.statement,
         microblock_size=args.microblock_size,
         keyfile=args.keyfile,
-        normalize=args.normalize,
     )
 
     network = LocalGossipNetwork()
@@ -50,7 +49,7 @@ def cmd_submit_statement(args: argparse.Namespace) -> None:
 
 def cmd_mine_statement(args: argparse.Namespace) -> None:
     """Mine ``args.text`` using :func:`miner.find_seed` and save the event."""
-    event = event_manager.create_event(args.text, normalize=args.normalize)
+    event = event_manager.create_event(args.text)
     block_total = len(event["microblocks"])
     for idx, block in enumerate(event["microblocks"], start=1):
         print(f"Mining microblock {idx}/{block_total} ...")
@@ -104,20 +103,10 @@ def build_parser() -> argparse.ArgumentParser:
         default=4,
         help="Microblock size in bytes",
     )
-    p_submit.add_argument(
-        "--normalize",
-        action="store_true",
-        help="Normalize statement before hashing",
-    )
     p_submit.set_defaults(func=cmd_submit_statement)
 
     p_mine = sub.add_parser("mine-statement", help="Mine microblocks for a statement")
     p_mine.add_argument("--text", required=True, help="Statement text")
-    p_mine.add_argument(
-        "--normalize",
-        action="store_true",
-        help="Normalize statement before hashing",
-    )
     p_mine.set_defaults(func=cmd_mine_statement)
 
     p_gen = sub.add_parser("generate-keys", help="Generate a keypair")

--- a/helix/statement_registry.py
+++ b/helix/statement_registry.py
@@ -8,23 +8,13 @@ from . import event_manager
 class StatementRegistry:
     """Registry of statement hashes to prevent exact duplicates."""
 
-    def __init__(self, hashes: Iterable[str] | None = None, *, normalize: bool = False) -> None:
-        """Create a new registry.
-
-        If ``normalize`` is ``True`` statements are normalized prior to hashing
-        so that near-duplicates resolve to the same identifier.
-        """
+    def __init__(self, hashes: Iterable[str] | None = None) -> None:
+        """Create a new registry."""
 
         self._hashes: Set[str] = set(hashes or [])
-        self.normalize = normalize
 
     def _hash_statement(self, statement: str) -> str:
-        text = (
-            event_manager.normalize_statement(statement)
-            if self.normalize
-            else statement
-        )
-        return event_manager.sha256(text.encode("utf-8"))
+        return event_manager.sha256(statement.encode("utf-8"))
 
     def check_and_add(self, statement: str) -> None:
         """Add ``statement`` if not already present else raise ``ValueError``."""

--- a/tests/test_statement_registry.py
+++ b/tests/test_statement_registry.py
@@ -42,8 +42,3 @@ def test_rebuild_from_events(tmp_path):
         event_manager.create_event("Finalized", registry=new_reg)
 
 
-def test_normalized_duplicate_detection():
-    registry = StatementRegistry(normalize=True)
-    event_manager.create_event("Aliens exist.", registry=registry, normalize=True)
-    with pytest.raises(ValueError):
-        event_manager.create_event("aliens exist", registry=registry, normalize=True)


### PR DESCRIPTION
## Summary
- drop normalization utilities from event manager
- remove normalize option from CLI and statement registry
- compute statement IDs from raw text only
- adjust tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dcd6dbfe08329b48f74abd77c7a83