### PR TITLE
Integrate nested seed mining

### DIFF
--- a/tests/test_nested_mining_node.py
+++ b/tests/test_nested_mining_node.py
@@ -34,4 +34,4 @@ def test_nested_mining_fallback(tmp_path, monkeypatch):
     node.mine_event(event)
 
     assert event["is_closed"]
-    assert event["seeds"][0]["depth"] == 2
+    assert event["seed_depths"][0] == 2

--- a/tests/test_simulate_mining.py
+++ b/tests/test_simulate_mining.py
@@ -17,8 +17,7 @@ def test_simulated_mining():
         seed = minihelix.mine_seed(block, max_attempts=100000)
         assert seed is not None
         assert minihelix.verify_seed(seed, block)
-        event["seeds"][idx] = {"seed": seed, "depth": 1}
-        event_manager.mark_mined(event, idx)
+        event_manager.accept_mined_seed(event, idx, seed, 1)
     assert event["is_closed"]
     final = event_manager.reassemble_microblocks(event["microblocks"])
     assert final == statement


### PR DESCRIPTION
## Summary
- mine microblocks using `nested_miner.find_nested_seed`
- store mined seeds as bytes with depths in `seed_depths`
- log when a mined seed is rejected
- update tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dcd7316a483299c693c77f80a4d34