### PR TITLE
Allow better seed replacement

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -133,13 +133,23 @@ def accept_mined_seed(event: Dict[str, Any], index: int, seed: bytes, depth: int
 
     old_seed = event["seeds"][index]
     old_depth = event["seed_depths"][index]
-    if len(old_seed) == len(seed) and depth < old_depth:
+
+    replace = False
+    if len(seed) < len(old_seed):
+        replace = True
+    elif len(seed) == len(old_seed) and depth < old_depth:
+        replace = True
+
+    if replace:
         refund = event["rewards"][index] - reward
         event["seeds"][index] = seed
         event["seed_depths"][index] = depth
         event["penalties"][index] = penalty
         event["rewards"][index] = reward
         event["refunds"][index] += refund
+        print(
+            f"Replaced seed at index {index}: length {len(old_seed)} depth {old_depth} -> length {len(seed)} depth {depth}"
+        )
 
     return refund
 

--- a/tests/test_nesting_penalty.py
+++ b/tests/test_nesting_penalty.py
@@ -14,11 +14,25 @@ def test_accept_mined_seed_replacement():
     original_reward = event["rewards"][0]
 
     refund = event_manager.accept_mined_seed(event, 0, b"a", 2)
-    assert refund > 0
+    expected_reward = event_manager.reward_for_depth(2)
+    assert refund == pytest.approx(original_reward - expected_reward)
     assert event["seed_depths"][0] == 2
     assert event["penalties"][0] == 1
     assert event["refunds"][0] == refund
-    assert event["rewards"][0] < original_reward
+    assert event["rewards"][0] == expected_reward
+
+
+def test_accept_mined_seed_shorter_replacement():
+    event = event_manager.create_event("abc", microblock_size=3)
+    event_manager.accept_mined_seed(event, 0, b"long", 2)
+    original_reward = event["rewards"][0]
+
+    refund = event_manager.accept_mined_seed(event, 0, b"a", 5)
+    expected_reward = event_manager.reward_for_depth(5)
+    assert event["seeds"][0] == b"a"
+    assert event["seed_depths"][0] == 5
+    assert refund == pytest.approx(original_reward - expected_reward)
+    assert event["refunds"][0] == refund
 
 
 def test_accept_mined_seed_conditions():
@@ -32,3 +46,7 @@ def test_accept_mined_seed_conditions():
     refund = event_manager.accept_mined_seed(event, 0, b"c", 3)
     assert refund == 0
     assert event["seed_depths"][0] == 2
+    # same depth should not replace
+    refund = event_manager.accept_mined_seed(event, 0, b"d", 2)
+    assert refund == 0
+    assert event["seeds"][0] == b"a"


### PR DESCRIPTION
## Summary
- replace already mined seeds with a better seed if it is shorter or shallower
- track refunds when a seed replacement occurs
- test seed replacement logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dcd7837e0832987935860c501f3bf