### PR TITLE
Modernize typing hints

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -2,7 +2,7 @@ import hashlib
 import math
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Tuple, TYPE_CHECKING, Optional
+from typing import Any, Dict, List, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .statement_registry import StatementRegistry
@@ -58,8 +58,8 @@ def create_event(
     microblock_size: int = DEFAULT_MICROBLOCK_SIZE,
     *,
     parent_id: str = GENESIS_HASH,
-    keyfile: Optional[str] = None,
-    registry: Optional["StatementRegistry"] = None,
+    keyfile: str | None = None,
+    registry: "StatementRegistry" | None = None,
 ) -> Dict[str, Any]:
     microblocks, block_count, total_len = split_into_microblocks(
         statement, microblock_size
@@ -156,7 +156,7 @@ def save_event(event: Dict[str, Any], directory: str) -> str:
     return str(filename)
 
 
-def validate_parent(event: Dict[str, Any], *, ancestors: Optional[set[str]] = None) -> None:
+def validate_parent(event: Dict[str, Any], *, ancestors: set[str] | None = None) -> None:
     if ancestors is None:
         ancestors = {GENESIS_HASH}
     parent_id = event.get("header", {}).get("parent_id")

--- a/helix/helix_node.py
+++ b/helix/helix_node.py
@@ -7,7 +7,7 @@ def mine_event(self, event: dict) -> None:
             continue
         simulate_mining(idx)
 
-        best_seed: Optional[bytes] = None
+        best_seed: bytes | None = None
         best_depth = 0
 
         # Attempt flat mining

--- a/helix/miner.py
+++ b/helix/miner.py
@@ -1,7 +1,6 @@
 import hashlib
 import os
 import random
-from typing import Optional
 
 
 def truncate_hash(data: bytes, length: int) -> bytes:
@@ -16,7 +15,7 @@ def generate_microblock(seed: bytes) -> bytes:
     return hashlib.sha256(input_data).digest()
 
 
-def find_seed(target: bytes, max_seed_len: int = 32, *, attempts: int = 1_000_000) -> Optional[bytes]:
+def find_seed(target: bytes, max_seed_len: int = 32, *, attempts: int = 1_000_000) -> bytes | None:
     """Search for a seed that generates `target` when truncated to len(target)."""
     target_len = len(target)
     for _ in range(attempts):

--- a/helix/minihelix.py
+++ b/helix/minihelix.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-from typing import Optional
 
 
 DEFAULT_MICROBLOCK_SIZE = 8
@@ -19,7 +18,7 @@ def G(seed: bytes, N: int = DEFAULT_MICROBLOCK_SIZE) -> bytes:
     return hashlib.sha256(data).digest()[:N]
 
 
-def mine_seed(target_block: bytes, max_attempts: int | None = None) -> Optional[bytes]:
+def mine_seed(target_block: bytes, max_attempts: int | None = None) -> bytes | None:
     """Brute-force search for a seed that regenerates ``target_block``."""
     N = len(target_block)
     attempt = 0

--- a/helix/nested_miner.py
+++ b/helix/nested_miner.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import os
 import random
-from typing import List, Optional, Tuple
+
 
 from .minihelix import G
 
 
 def find_nested_seed(
     target_block: bytes, max_depth: int = 3, *, attempts: int = 1_000_000
-) -> Optional[Tuple[List[bytes], int]]:
+) -> tuple[list[bytes], int] | None:
     """Search for a seed that produces ``target_block`` through nested ``G``.
 
     Returns a tuple of ``(seed_chain, depth)`` where ``seed_chain`` contains
@@ -35,7 +35,7 @@ def find_nested_seed(
     return None
 
 
-def verify_nested_seed(seed_chain: List[bytes], target_block: bytes) -> bool:
+def verify_nested_seed(seed_chain: list[bytes], target_block: bytes) -> bool:
     """Return ``True`` if applying ``G`` over ``seed_chain`` yields ``target_block``."""
 
     if not seed_chain:

--- a/helix/network/tcp_transport.py
+++ b/helix/network/tcp_transport.py
@@ -6,7 +6,7 @@ import json
 import socket
 import threading
 import queue
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 from .peer import Peer
 from .transport import GossipTransport
@@ -51,7 +51,7 @@ class TCPGossipTransport(GossipTransport):
         with socket.create_connection((peer.host, peer.port)) as sock:
             sock.sendall(data)
 
-    def receive(self, timeout: Optional[float] = None) -> tuple[Peer, Dict[str, Any]]:
+    def receive(self, timeout: float | None = None) -> tuple[Peer, Dict[str, Any]]:
         return self._recv_queue.get(timeout=timeout)
 
     def add_peer(self, peer: Peer) -> None:

--- a/helix/peer_discovery.py
+++ b/helix/peer_discovery.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 import threading
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from .gossip import GossipNode
 
@@ -34,7 +34,7 @@ class PeerDiscovery:
         self.ping_interval = ping_interval
         self.known_peers: set[str] = set()
         self._stop = threading.Event()
-        self._thread: Optional[threading.Thread] = None
+        self._thread: threading.Thread | None = None
         self.load_peers()
 
     # persistence ---------------------------------------------------------

--- a/helix/ui.py
+++ b/helix/ui.py
@@ -1,12 +1,11 @@
 import json
 import threading
-from typing import Optional
 
 from .betting_interface import submit_bet, record_bet
 from .helix_node import HelixNode, GossipMessageType
 
 
-def run_cli(node: HelixNode, *, keyfile: Optional[str] = None) -> None:
+def run_cli(node: HelixNode, *, keyfile: str | None = None) -> None:
     """Simple interactive CLI for a :class:`HelixNode`."""
 
     threading.Thread(target=node._message_loop, daemon=True).start()


### PR DESCRIPTION
## Summary
- modernize Optional usage with Python 3.10 union syntax
- drop unused Optional imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dda1fe1f483299f6a4d6ff8bbde70