### PR TITLE
Allow block-size seeds

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -112,6 +112,10 @@ def accept_mined_seed(event: Dict[str, Any], index: int, seed: bytes, depth: int
     reward = reward_for_depth(depth)
     refund = 0.0
 
+    microblock_size = event.get("header", {}).get("microblock_size", DEFAULT_MICROBLOCK_SIZE)
+    if len(seed) > microblock_size:
+        raise ValueError("seed length exceeds microblock size")
+
     if event["seeds"][index] is None:
         event["seeds"][index] = seed
         event["seed_depths"][index] = depth

--- a/tests/test_event_manager.py
+++ b/tests/test_event_manager.py
@@ -22,3 +22,17 @@ def test_event_closure():
     for i in range(event["header"]["block_count"]):
         em.mark_mined(event, i)
     assert event["is_closed"] is True
+
+
+def test_accept_block_size_seed():
+    event = em.create_event("ab", microblock_size=2)
+    seed = b"xy"
+    refund = em.accept_mined_seed(event, 0, seed, 1)
+    assert refund == 0
+    assert event["seeds"][0] == seed
+
+
+def test_reject_oversize_seed():
+    event = em.create_event("ab", microblock_size=2)
+    with pytest.raises(ValueError):
+        em.accept_mined_seed(event, 0, b"toolong", 1)


### PR DESCRIPTION
## Summary
- allow seeds up to the microblock size in `accept_mined_seed`
- add test for block-sized seeds and oversize rejection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dda4592708329b66641ca74075b63