### PR TITLE
Prevent duplicate finalized statements

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -66,6 +66,11 @@ def create_event(
     )
     statement_id = sha256(statement.encode("utf-8"))
     if registry is not None:
+        if registry.has_id(statement_id):
+            print(
+                f"Duplicate statement_id {statement_id} already finalized; skipping"
+            )
+            raise ValueError("Duplicate statement")
         registry.check_and_add(statement)
 
     header = {

--- a/helix/statement_registry.py
+++ b/helix/statement_registry.py
@@ -20,8 +20,13 @@ class StatementRegistry:
         """Add ``statement`` if not already present else raise ``ValueError``."""
         h = self._hash_statement(statement)
         if h in self._hashes:
+            print(f"Duplicate statement detected: {h}")
             raise ValueError("Duplicate statement")
         self._hashes.add(h)
+
+    def has_id(self, statement_id: str) -> bool:
+        """Return ``True`` if ``statement_id`` is known."""
+        return statement_id in self._hashes
 
     def has(self, statement: str) -> bool:
         return self._hash_statement(statement) in self._hashes


### PR DESCRIPTION
## Summary
- prevent new events from reusing finalized statement IDs
- warn when a duplicate statement is submitted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ddb71354c8329a0647f33fc58535a