### PR TITLE
Add event archive utility

### DIFF
--- a/helix/__init__.py
+++ b/helix/__init__.py
@@ -12,4 +12,5 @@ __all__ = [
     "gossip",
     "peer_discovery",
     "ui",
+    "archive",
 ]

--- a/helix/archive.py
+++ b/helix/archive.py
@@ -1,0 +1,58 @@
+import json
+import gzip
+import os
+from pathlib import Path
+from typing import List
+
+from . import event_manager
+
+
+def _create_bundle(events: List[dict]) -> bytes:
+    """Return gzipped JSON bytes for a list of finalized events."""
+    events_json = json.dumps(events).encode("utf-8")
+    compressed = gzip.compress(events_json)
+    size_saved = len(events_json) - len(compressed)
+    ratio = len(events_json) / len(compressed) if len(compressed) else 0
+
+    bundle = {
+        "metadata": {
+            "total_events": len(events),
+            "size_saved": size_saved,
+            "compression_ratio": ratio,
+        },
+        "events": events,
+    }
+    bundle_json = json.dumps(bundle).encode("utf-8")
+    return gzip.compress(bundle_json)
+
+
+def archive_finalized_events(events_dir: str, archive_dir: str, bundle_size: int = 100) -> List[str]:
+    """Bundle finalized events from ``events_dir`` and store them compressed.
+
+    Returns a list of created bundle file paths.
+    """
+    finalized = []
+    if os.path.isdir(events_dir):
+        for fname in sorted(os.listdir(events_dir)):
+            if not fname.endswith(".json"):
+                continue
+            try:
+                event = event_manager.load_event(os.path.join(events_dir, fname))
+            except Exception:
+                continue
+            if event.get("is_closed"):
+                finalized.append(event)
+
+    Path(archive_dir).mkdir(parents=True, exist_ok=True)
+    paths = []
+    for start in range(0, len(finalized), bundle_size):
+        chunk = finalized[start:start + bundle_size]
+        data = _create_bundle(chunk)
+        file_path = Path(archive_dir) / f"bundle_{start // bundle_size}.json.gz"
+        with open(file_path, "wb") as fh:
+            fh.write(data)
+        paths.append(str(file_path))
+    return paths
+
+
+__all__ = ["archive_finalized_events"]

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,37 @@
+import gzip
+import json
+import os
+
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import event_manager as em
+from helix import archive
+
+
+def _finalize_event(event: dict) -> None:
+    for idx in range(event["header"]["block_count"]):
+        em.mark_mined(event, idx)
+
+
+def test_archive_bundles(tmp_path):
+    events_dir = tmp_path / "events"
+    archives_dir = tmp_path / "archives"
+
+    events = []
+    for text in ["a", "b", "c"]:
+        ev = em.create_event(text, microblock_size=2)
+        _finalize_event(ev)
+        em.save_event(ev, str(events_dir))
+        events.append(ev)
+
+    paths = archive.archive_finalized_events(str(events_dir), str(archives_dir), bundle_size=2)
+    assert len(paths) == 2
+    for p, expected_len in zip(paths, [2, 1]):
+        assert os.path.exists(p)
+        with gzip.open(p, "rb") as fh:
+            data = json.load(fh)
+        assert data["metadata"]["total_events"] == expected_len
+        assert len(data["events"]) == expected_len
+        assert data["metadata"]["compression_ratio"] > 0


### PR DESCRIPTION
## Summary
- add `archive.py` to compress finalized events into bundles
- export `archive` module
- test archiving finalized events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ddb76a7688329a6f70e5bcae00fe8