### PR TITLE
Add compression statistics to ledger and CLI

### DIFF
--- a/helix/cli.py
+++ b/helix/cli.py
@@ -7,7 +7,7 @@ from . import event_manager
 from . import nested_miner
 from . import minihelix
 from . import betting_interface
-from .ledger import load_balances
+from .ledger import load_balances, compression_stats
 
 
 def cmd_status(args: argparse.Namespace) -> None:
@@ -18,10 +18,13 @@ def cmd_status(args: argparse.Namespace) -> None:
     known_peers = len(node.known_peers)
     total_events = len(node.events)
     finalized_events = sum(1 for e in node.events.values() if e.get("is_closed"))
+    saved, hlx = compression_stats(str(events_dir))
     balances = load_balances(str(balances_file))
     print(f"Known peers: {known_peers}")
     print(f"Events loaded: {total_events}")
     print(f"Events finalized: {finalized_events}")
+    print(f"Compression saved: {saved} bytes")
+    print(f"HLX awarded: {hlx}")
     print("Balances:")
     print(json.dumps(balances, indent=2))
 

--- a/helix/ledger.py
+++ b/helix/ledger.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Tuple
+
+from . import event_manager
 
 
 def load_balances(path: str) -> Dict[str, float]:
@@ -19,4 +21,37 @@ def save_balances(balances: Dict[str, float], path: str) -> None:
         json.dump(balances, f, indent=2)
 
 
-__all__ = ["load_balances", "save_balances"]
+def compression_stats(events_dir: str) -> Tuple[int, float]:
+    """Return total bytes saved and HLX earned across finalized events.
+
+    Parameters
+    ----------
+    events_dir:
+        Directory containing event JSON files.
+    """
+
+    path = Path(events_dir)
+    if not path.exists():
+        return 0, 0.0
+
+    saved = 0
+    hlx = 0.0
+    for event_file in path.glob("*.json"):
+        event = event_manager.load_event(str(event_file))
+        if not event.get("is_closed"):
+            continue
+        micro_size = event["header"].get(
+            "microblock_size", event_manager.DEFAULT_MICROBLOCK_SIZE
+        )
+        for seed in event.get("seeds", []):
+            if seed is None:
+                continue
+            saved += max(0, micro_size - len(seed))
+        rewards = event.get("rewards", [])
+        refunds = event.get("refunds", [])
+        hlx += sum(rewards) - sum(refunds)
+
+    return saved, hlx
+
+
+__all__ = ["load_balances", "save_balances", "compression_stats"]

--- a/tests/test_compression_stats.py
+++ b/tests/test_compression_stats.py
@@ -1,0 +1,18 @@
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import event_manager
+from helix.ledger import compression_stats
+
+
+def test_compression_stats(tmp_path):
+    events_dir = tmp_path / "events"
+    event = event_manager.create_event("abcd", microblock_size=2)
+    for idx, block in enumerate(event["microblocks"]):
+        event_manager.accept_mined_seed(event, idx, b"a", 1)
+    event_manager.save_event(event, str(events_dir))
+
+    saved, hlx = compression_stats(str(events_dir))
+    assert saved == event["header"]["block_count"]
+    assert hlx == pytest.approx(sum(event["rewards"]))


### PR DESCRIPTION
## Summary
- compute compression stats over finalized events
- show saved bytes and estimated HLX in `helix-cli status`
- test compression_stats helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ddb85ef848329bfa988c4ff68b871