### PR TITLE
Implement remine-microblock command

### DIFF
--- a/helix/cli.py
+++ b/helix/cli.py
@@ -71,6 +71,44 @@ def cmd_mine(args: argparse.Namespace) -> None:
     event_manager.save_event(event, str(events_dir))
 
 
+def cmd_remine_microblock(args: argparse.Namespace) -> None:
+    """Attempt to mine or replace a single microblock."""
+    events_dir = Path(args.data_dir) / "events"
+    event_path = events_dir / f"{args.event_id}.json"
+    if not event_path.exists():
+        print("Event not found")
+        return
+    event = _load_event(event_path)
+
+    if event.get("is_closed"):
+        print("Event is closed")
+        return
+
+    index = args.index
+    if index < 0 or index >= len(event["microblocks"]):
+        print("Invalid index")
+        return
+
+    if event["mined_status"][index] and not args.force:
+        print("Microblock already mined; use --force to replace")
+        return
+
+    block = event["microblocks"][index]
+    result = nested_miner.find_nested_seed(block)
+    if result is None:
+        print(f"No seed found for block {index}")
+        return
+    chain, depth = result
+    if not nested_miner.verify_nested_seed(chain, block):
+        print(f"Seed verification failed for block {index}")
+        return
+
+    seed = chain[0]
+    event_manager.accept_mined_seed(event, index, seed, depth)
+    event_manager.save_event(event, str(events_dir))
+    print(f"Remined microblock {index}")
+
+
 def cmd_place_bet(args: argparse.Namespace) -> None:
     events_dir = Path(args.data_dir) / "events"
     event_path = events_dir / f"{args.event_id}.json"
@@ -143,6 +181,18 @@ def main(argv: list[str] | None = None) -> None:
 
     p_wallet = sub.add_parser("view-wallet", help="View wallet balances")
     p_wallet.set_defaults(func=cmd_view_wallet)
+
+    p_remine = sub.add_parser(
+        "remine-microblock", help="Retry mining a single microblock"
+    )
+    p_remine.add_argument("--event-id", required=True, help="Event identifier")
+    p_remine.add_argument("--index", type=int, required=True, help="Block index")
+    p_remine.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace existing seed if a shorter one is found",
+    )
+    p_remine.set_defaults(func=cmd_remine_microblock)
 
     p_status = sub.add_parser("status", help="Show node status")
     p_status.set_defaults(func=cmd_status)

--- a/tests/test_cli_remine_microblock.py
+++ b/tests/test_cli_remine_microblock.py
@@ -1,0 +1,65 @@
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import cli, event_manager
+
+
+def _create_event(tmp_path):
+    event = event_manager.create_event("abcdef", microblock_size=3)
+    event_manager.accept_mined_seed(event, 0, b"long", 1)
+    event_manager.save_event(event, str(tmp_path / "events"))
+    return event
+
+
+def test_remine_requires_force(tmp_path, monkeypatch):
+    event = _create_event(tmp_path)
+    evt_id = event["header"]["statement_id"]
+
+    monkeypatch.setattr(
+        "helix.cli.nested_miner.find_nested_seed", lambda block: ([b"a"], 1)
+    )
+    monkeypatch.setattr(
+        "helix.cli.nested_miner.verify_nested_seed", lambda chain, block: True
+    )
+
+    cli.main(
+        [
+            "--data-dir",
+            str(tmp_path),
+            "remine-microblock",
+            "--event-id",
+            evt_id,
+            "--index",
+            "0",
+        ]
+    )
+    reloaded = event_manager.load_event(str(tmp_path / "events" / f"{evt_id}.json"))
+    assert reloaded["seeds"][0] == b"long"
+
+
+def test_remine_with_force(tmp_path, monkeypatch):
+    event = _create_event(tmp_path)
+    evt_id = event["header"]["statement_id"]
+
+    monkeypatch.setattr(
+        "helix.cli.nested_miner.find_nested_seed", lambda block: ([b"a"], 1)
+    )
+    monkeypatch.setattr(
+        "helix.cli.nested_miner.verify_nested_seed", lambda chain, block: True
+    )
+
+    cli.main(
+        [
+            "--data-dir",
+            str(tmp_path),
+            "remine-microblock",
+            "--event-id",
+            evt_id,
+            "--index",
+            "0",
+            "--force",
+        ]
+    )
+    reloaded = event_manager.load_event(str(tmp_path / "events" / f"{evt_id}.json"))
+    assert reloaded["seeds"][0] == b"a"


### PR DESCRIPTION
## Summary
- add `remine-microblock` command to cli
- allow retrying a single microblock when event isn't closed
- add optional `--force` flag to attempt replacement of existing seed
- add tests covering the new command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ddb9221c88329865f6b987be8992a