### PR TITLE
Add hybrid_mine function for nested mining

### DIFF
--- a/tests/test_hybrid_miner.py
+++ b/tests/test_hybrid_miner.py
@@ -1,0 +1,9 @@
+from helix import minihelix, nested_miner
+
+
+def test_hybrid_mine_simple():
+    seed = b"\x01"
+    # Create a target that is two applications of G on the seed
+    target = minihelix.G(minihelix.G(seed, N=1), N=1)
+    result = nested_miner.hybrid_mine(target, max_depth=2)
+    assert result == (seed, 2)


### PR DESCRIPTION
## Summary
- implement `hybrid_mine` in `nested_miner.py` to search sequentially for nested seeds
- expose the new function via `__all__`
- add tests covering simple two-level mining

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df722c4348329bf0c795681d8d888