### PR TITLE
Add calculate_reward helper

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -25,6 +25,21 @@ def reward_for_depth(depth: int) -> float:
     return BASE_REWARD / depth
 
 
+def calculate_reward(base: float, depth: int) -> float:
+    """Return the reward for ``depth`` using ``base`` tokens.
+
+    Reward scales inversely with the depth of the mined seed.  A depth-1
+    seed receives the full ``base`` amount, depth-2 receives half, and so
+    on.  The result is rounded to four decimal places.
+    """
+
+    if depth < 1:
+        raise ValueError("depth must be >= 1")
+
+    reward = base / depth
+    return round(reward, 4)
+
+
 def sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
@@ -217,6 +232,7 @@ __all__ = [
     "mark_mined",
     "nesting_penalty",
     "reward_for_depth",
+    "calculate_reward",
     "accept_mined_seed",
     "save_event",
     "verify_originator_signature",

--- a/tests/test_calculate_reward.py
+++ b/tests/test_calculate_reward.py
@@ -1,0 +1,22 @@
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import event_manager as em
+
+
+def test_reward_depth_one():
+    assert em.calculate_reward(1.0, 1) == 1.0
+
+
+def test_reward_depth_two():
+    assert em.calculate_reward(2.0, 2) == 1.0
+
+
+def test_reward_rounding():
+    assert em.calculate_reward(1.0, 3) == 0.3333
+
+
+def test_reward_invalid_depth():
+    with pytest.raises(ValueError):
+        em.calculate_reward(1.0, 0)


### PR DESCRIPTION
## Summary
- extend event_manager with `calculate_reward`
- export the function
- test that `calculate_reward` behaves as expected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df729fe608329915b87c8da15864a