### PR TITLE
Verify nested chain before accepting mined seed

### DIFF
--- a/helix/cli.py
+++ b/helix/cli.py
@@ -63,13 +63,12 @@ def cmd_mine(args: argparse.Namespace) -> None:
         if result is None:
             print(f"No seed found for block {idx}")
             continue
-        chain, _ = result
-        seed = chain[0]
-        if not minihelix.verify_seed(seed, block):
+        chain, depth = result
+        if not nested_miner.verify_nested_seed(chain, block):
             print(f"Seed verification failed for block {idx}")
             continue
-        event["seeds"][idx] = seed
-        event_manager.mark_mined(event, idx)
+        seed = chain[0]
+        event_manager.accept_mined_seed(event, idx, seed, depth)
         print(f"Mined microblock {idx}")
     event_manager.save_event(event, str(events_dir))
 

--- a/helix/helix_node.py
+++ b/helix/helix_node.py
@@ -245,6 +245,8 @@ class HelixNode(GossipNode):
                 result = nested_miner.find_nested_seed(block, max_depth=depth)
                 if result:
                     chain, found_depth = result
+                    if not nested_miner.verify_nested_seed(chain, block):
+                        continue
                     candidate = chain[0]
                     if (
                         best_seed is None

--- a/tests/test_cli_mine_nested.py
+++ b/tests/test_cli_mine_nested.py
@@ -1,0 +1,22 @@
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import cli, event_manager, minihelix
+
+
+def test_cli_mine_nested(tmp_path, monkeypatch):
+    event = event_manager.create_event("ab", microblock_size=2)
+    event_manager.save_event(event, str(tmp_path / "events"))
+    evt_id = event["header"]["statement_id"]
+
+    chain = [b"a", minihelix.G(b"a", 2)]
+    monkeypatch.setattr("helix.cli.nested_miner.find_nested_seed", lambda block: (chain, 2))
+    monkeypatch.setattr("helix.cli.nested_miner.verify_nested_seed", lambda c, b: True)
+
+    cli.main(["--data-dir", str(tmp_path), "mine", evt_id])
+
+    reloaded = event_manager.load_event(str(tmp_path / "events" / f"{evt_id}.json"))
+    assert reloaded["is_closed"]
+    assert reloaded["seed_depths"][0] == 2
+    assert reloaded["seeds"][0] == b"a"


### PR DESCRIPTION
## Summary
- verify nested seed chain in CLI mining command
- check nested seed chain during HelixNode mining
- test multi-depth nested mining via CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df7589a6883298498e7d19f74f035