### PR TITLE
Add statement signature and verification

### DIFF
--- a/genesis.py
+++ b/genesis.py
@@ -25,8 +25,8 @@ GENESIS_FILE = "genesis.json"
 
 
 def main() -> None:
-    load_or_create_keys(KEYFILE)
-    event = create_event(STATEMENT, microblock_size=MICROBLOCK_SIZE, keyfile=KEYFILE)
+    _, priv = load_or_create_keys(KEYFILE)
+    event = create_event(STATEMENT, microblock_size=MICROBLOCK_SIZE, private_key=priv)
 
     for index, block in enumerate(event["microblocks"]):
         seed = mine_seed(block)

--- a/helix/cli.py
+++ b/helix/cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from .helix_node import HelixNode
 from . import event_manager
+from . import signature_utils as su
 from . import nested_miner
 from . import minihelix
 from . import betting_interface
@@ -43,7 +44,10 @@ def cmd_start_node(args: argparse.Namespace) -> None:
 
 def cmd_submit_statement(args: argparse.Namespace) -> None:
     events_dir = Path(args.data_dir) / "events"
-    event = event_manager.create_event(args.statement, keyfile=args.keyfile)
+    private_key = None
+    if args.keyfile:
+        _, private_key = su.load_keys(args.keyfile)
+    event = event_manager.create_event(args.statement, private_key=private_key)
     path = event_manager.save_event(event, str(events_dir))
     print(f"Statement saved to {path}")
     print(f"Statement ID: {event['header']['statement_id']}")

--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -1,6 +1,7 @@
 import hashlib
 import math
 import json
+import base64
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, TYPE_CHECKING, Optional
 
@@ -8,6 +9,7 @@ if TYPE_CHECKING:
     from .statement_registry import StatementRegistry
 
 from .signature_utils import load_keys, sign_data, verify_signature
+from nacl import signing
 from .config import GENESIS_HASH
 
 DEFAULT_MICROBLOCK_SIZE = 8  # bytes
@@ -58,7 +60,7 @@ def create_event(
     microblock_size: int = DEFAULT_MICROBLOCK_SIZE,
     *,
     parent_id: str = GENESIS_HASH,
-    keyfile: Optional[str] = None,
+    private_key: Optional[str] = None,
     registry: Optional["StatementRegistry"] = None,
 ) -> Dict[str, Any]:
     microblocks, block_count, total_len = split_into_microblocks(
@@ -81,11 +83,15 @@ def create_event(
         "parent_id": parent_id,
     }
 
-    if keyfile is not None:
-        pub, priv = load_keys(keyfile)
-        signature = sign_data(repr(header).encode("utf-8"), priv)
-        header["originator_sig"] = signature
-        header["originator_pub"] = pub
+    originator_pub: Optional[str] = None
+    originator_sig: Optional[str] = None
+    if private_key is not None:
+        key_bytes = base64.b64decode(private_key)
+        signing_key = signing.SigningKey(key_bytes)
+        originator_pub = base64.b64encode(signing_key.verify_key.encode()).decode(
+            "ascii"
+        )
+        originator_sig = sign_data(statement.encode("utf-8"), private_key)
 
     event = {
         "header": header,
@@ -100,6 +106,9 @@ def create_event(
         "is_closed": False,
         "bets": {"YES": [], "NO": []},
     }
+    if originator_pub is not None:
+        event["originator_pub"] = originator_pub
+        event["originator_sig"] = originator_sig
     return event
 
 
@@ -185,6 +194,21 @@ def verify_originator_signature(event: Dict[str, Any]) -> bool:
     return True
 
 
+def verify_event_signature(event: Dict[str, Any]) -> bool:
+    """Verify the signature for ``event`` recorded at the root level."""
+    signature = event.get("originator_sig")
+    pubkey = event.get("originator_pub")
+    statement = event.get("statement")
+
+    if signature is None or pubkey is None or statement is None:
+        return False
+
+    if not verify_signature(statement.encode("utf-8"), signature, pubkey):
+        raise ValueError("Invalid event signature")
+
+    return True
+
+
 def validate_parent(event: Dict[str, Any], *, ancestors: Optional[set[str]] = None) -> None:
     if ancestors is None:
         ancestors = {GENESIS_HASH}
@@ -220,6 +244,7 @@ __all__ = [
     "accept_mined_seed",
     "save_event",
     "verify_originator_signature",
+    "verify_event_signature",
     "load_event",
     "validate_parent",
 ]

--- a/helix/helix_node.py
+++ b/helix/helix_node.py
@@ -209,12 +209,12 @@ class HelixNode(GossipNode):
             event_manager.save_event(event, self.events_dir)
         save_balances(self.balances, self.balances_file)
 
-    def create_event(self, statement: str, *, keyfile: Optional[str] = None) -> dict:
+    def create_event(self, statement: str, *, private_key: Optional[str] = None) -> dict:
         return event_manager.create_event(
             statement,
             microblock_size=self.microblock_size,
             parent_id=GENESIS_HASH,
-            keyfile=keyfile,
+            private_key=private_key,
         )
 
     def import_event(self, event: dict) -> None:

--- a/setup_genesis.py
+++ b/setup_genesis.py
@@ -63,10 +63,11 @@ def main() -> None:
     balances = {pubkey: {"balance": 0, "genesis_tokens": 1000}}
     save_balances(balances, BALANCES_FILE)
 
+
     event = create_event(
         STATEMENT,
         microblock_size=MICROBLOCK_SIZE,
-        keyfile=KEYFILE,
+        private_key=privkey,
     )
     _mine_microblocks(event)
     path = save_event(event, EVENTS_DIR)

--- a/tests/test_nested_mining_node.py
+++ b/tests/test_nested_mining_node.py
@@ -27,7 +27,7 @@ def test_nested_mining_fallback(tmp_path, monkeypatch):
         lambda target, max_depth: (chain, 2),
     )
 
-    event = node.create_event("ab", keyfile=None)
+    event = node.create_event("ab", private_key=None)
     evt_id = event["header"]["statement_id"]
     node.events[evt_id] = event
 

--- a/tests/test_statement_submission.py
+++ b/tests/test_statement_submission.py
@@ -4,24 +4,21 @@ import pytest
 pytest.importorskip("nacl")
 
 from helix import event_manager as em
-from helix.helix_node import verify_originator_signature
+from helix.event_manager import verify_event_signature
 from helix import signature_utils as su
 
 
-def test_create_event_with_signature(tmp_path):
+def test_create_event_with_signature():
     statement = "Helix test statement"
     pub, priv = su.generate_keypair()
-    keyfile = tmp_path / "keys.txt"
-    su.save_keys(str(keyfile), pub, priv)
-
-    event = em.create_event(statement, microblock_size=4, keyfile=str(keyfile))
+    event = em.create_event(statement, microblock_size=4, private_key=priv)
 
     header_hash = hashlib.sha256(statement.encode("utf-8")).hexdigest()
     assert event["header"]["statement_id"] == header_hash
     assert len(event["microblocks"]) == event["header"]["block_count"]
-    assert verify_originator_signature(event)
+    assert verify_event_signature(event)
 
 
 def test_create_event_without_signature():
     event = em.create_event("No sig", microblock_size=4)
-    assert not verify_originator_signature(event)
+    assert not verify_event_signature(event)


### PR DESCRIPTION
## Summary
- sign events with a provided private key
- keep public key/signature on the event
- add a helper to verify event signatures
- adapt CLI, HelixNode, and scripts for new API
- update tests for new signing logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df73ac4a88329ac0ffb2417970759