### PR TITLE
Implement gas deduction on statement submission

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -15,6 +15,8 @@ from .config import GENESIS_HASH
 DEFAULT_MICROBLOCK_SIZE = 8  # bytes
 FINAL_BLOCK_PADDING_BYTE = b"\x00"
 BASE_REWARD = 1.0
+# Base gas cost applied per microblock when a statement is submitted
+GAS_FEE_PER_MICROBLOCK = 1
 
 
 def nesting_penalty(depth: int) -> int:
@@ -96,6 +98,7 @@ def create_event(
         "microblock_size": microblock_size,
         "block_count": block_count,
         "parent_id": parent_id,
+        "gas_fee": block_count * GAS_FEE_PER_MICROBLOCK,
     }
 
     originator_pub: Optional[str] = None
@@ -250,6 +253,7 @@ def load_event(path: str) -> Dict[str, Any]:
 __all__ = [
     "DEFAULT_MICROBLOCK_SIZE",
     "FINAL_BLOCK_PADDING_BYTE",
+    "GAS_FEE_PER_MICROBLOCK",
     "split_into_microblocks",
     "reassemble_microblocks",
     "create_event",

--- a/helix/helix_node.py
+++ b/helix/helix_node.py
@@ -104,12 +104,20 @@ class HelixNode(GossipNode):
         save_balances(self.balances, self.balances_file)
 
     def create_event(self, statement: str, *, private_key: Optional[str] = None) -> dict:
-        return event_manager.create_event(
+        event = event_manager.create_event(
             statement,
             microblock_size=self.microblock_size,
             parent_id=GENESIS_HASH,
             private_key=private_key,
         )
+        gas_fee = event["header"].get("gas_fee", 0)
+        originator = event.get("originator_pub")
+        if originator and gas_fee:
+            balance = self.balances.get(originator, 0)
+            if balance < gas_fee:
+                raise ValueError("insufficient funds")
+            self.balances[originator] = balance - gas_fee
+        return event
 
     def import_event(self, event: dict) -> None:
         if event.get("header", {}).get("parent_id") != GENESIS_HASH:

--- a/tests/test_gas_fee.py
+++ b/tests/test_gas_fee.py
@@ -1,0 +1,24 @@
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix.helix_node import HelixNode
+from helix.gossip import LocalGossipNetwork
+from helix import signature_utils
+
+
+def test_gas_fee_deducted(tmp_path):
+    network = LocalGossipNetwork()
+    node = HelixNode(
+        events_dir=str(tmp_path / "events"),
+        balances_file=str(tmp_path / "balances.json"),
+        network=network,
+        microblock_size=2,
+    )
+    pub, priv = signature_utils.generate_keypair()
+    node.balances[pub] = 10
+
+    event = node.create_event("hello", private_key=priv)
+    fee = event["header"].get("gas_fee")
+    assert fee == event["header"]["block_count"]
+    assert node.balances[pub] == 10 - fee


### PR DESCRIPTION
## Summary
- track a gas fee cost per microblock when creating events
- deduct this fee from the originator's wallet when a node submits a statement
- test gas fee deduction logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dfa1150888329b153636ee3d72f47