### PR TITLE
Add signed microblock gossip

### DIFF
--- a/tests/test_microblock_signature.py
+++ b/tests/test_microblock_signature.py
@@ -1,0 +1,59 @@
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix.helix_node import HelixNode, GossipMessageType
+from helix.gossip import LocalGossipNetwork
+from helix import event_manager, signature_utils
+
+
+def test_signed_microblock_replacement(tmp_path):
+    network = LocalGossipNetwork()
+    pub, priv = signature_utils.generate_keypair()
+    node_a = HelixNode(
+        events_dir=str(tmp_path / "a_events"),
+        balances_file=str(tmp_path / "a_bal.json"),
+        node_id="A",
+        network=network,
+        microblock_size=2,
+        public_key=pub,
+        private_key=priv,
+    )
+    node_b = HelixNode(
+        events_dir=str(tmp_path / "b_events"),
+        balances_file=str(tmp_path / "b_bal.json"),
+        node_id="B",
+        network=network,
+        microblock_size=2,
+    )
+
+    event = node_a.create_event("ab")
+    evt_id = event["header"]["statement_id"]
+    node_a.events[evt_id] = event
+    node_b.events[evt_id] = event_manager.create_event("ab", microblock_size=2)
+
+    event_b = node_b.events[evt_id]
+    event_manager.accept_mined_seed(event_b, 0, b"long", 3)
+
+    seed = b"a"
+    depth = 2
+    payload = f"{evt_id}:0:{seed.hex()}:{depth}".encode("utf-8")
+    sig = signature_utils.sign_data(payload, priv)
+    msg = {
+        "type": GossipMessageType.MINED_MICROBLOCK,
+        "event_id": evt_id,
+        "index": 0,
+        "seed": seed.hex(),
+        "depth": depth,
+        "pubkey": pub,
+        "signature": sig,
+    }
+    node_b._handle_message(msg)
+    assert event_b["seeds"][0] == seed
+    assert event_b["seed_depths"][0] == depth
+
+    wrong = msg.copy()
+    wrong["signature"] = signature_utils.sign_data(b"bad", priv)
+    node_b._handle_message(wrong)
+    assert event_b["seeds"][0] == seed
+


### PR DESCRIPTION
## Summary
- add key generation to `HelixNode`
- sign microblock messages when mining
- verify signatures for incoming microblock gossip
- add test for signed microblock replacement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dfa2f0be883299e66eb710ae43b4f