### PR TITLE
Add persistent peer storage

### DIFF
--- a/helix/peer_discovery.py
+++ b/helix/peer_discovery.py
@@ -5,9 +5,19 @@ from __future__ import annotations
 import json
 import os
 import threading
+import time
+from dataclasses import dataclass, asdict
 from typing import Any, Dict
 
 from .gossip import GossipNode
+from .network import Peer, SocketGossipNetwork
+
+
+@dataclass
+class PeerInfo:
+    host: str
+    port: int
+    last_seen: float = 0.0
 
 
 class PeerDiscoveryMessageType:
@@ -26,27 +36,42 @@ class PeerDiscovery:
         self,
         node: GossipNode,
         *,
+        host: str = "0.0.0.0",
+        port: int = 0,
         peers_file: str = "peers.json",
         ping_interval: float = 30.0,
     ) -> None:
         self.node = node
+        self.host = host
+        self.port = port
         self.peers_file = peers_file
         self.ping_interval = ping_interval
-        self.known_peers: set[str] = set()
+        self.known_peers: dict[str, PeerInfo] = {}
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self.load_peers()
+        self._reconnect_peers()
 
     # persistence ---------------------------------------------------------
     def load_peers(self) -> None:
-        """Load peer IDs from ``self.peers_file`` into ``known_peers``."""
+        """Load peer information from ``self.peers_file``."""
 
         if os.path.exists(self.peers_file):
             try:
                 with open(self.peers_file, "r", encoding="utf-8") as fh:
                     peers = json.load(fh)
                 if isinstance(peers, list):
-                    self.known_peers.update(peers)
+                    for peer in peers:
+                        if not isinstance(peer, dict):
+                            continue
+                        node_id = peer.get("node_id")
+                        host = peer.get("host")
+                        port = peer.get("port")
+                        last_seen = peer.get("last_seen", 0.0)
+                        if node_id and host and isinstance(port, int):
+                            self.known_peers[node_id] = PeerInfo(
+                                host=str(host), port=int(port), last_seen=float(last_seen)
+                            )
             except Exception as exc:  # pragma: no cover - graceful fail
                 print(f"Error loading peers: {exc}")
 
@@ -54,17 +79,34 @@ class PeerDiscovery:
         """Persist ``known_peers`` to ``self.peers_file``."""
 
         try:
+            data = [
+                {"node_id": nid, **asdict(info)} for nid, info in self.known_peers.items()
+            ]
             with open(self.peers_file, "w", encoding="utf-8") as fh:
-                json.dump(sorted(self.known_peers), fh, indent=2)
+                json.dump(data, fh, indent=2)
         except Exception as exc:  # pragma: no cover - graceful fail
             print(f"Error saving peers: {exc}")
+
+    def _reconnect_peers(self) -> None:
+        """Attempt to re-register any saved peers with the network."""
+
+        if not isinstance(self.node.network, SocketGossipNetwork):
+            return
+        for node_id, info in self.known_peers.items():
+            peer = Peer(info.host, info.port)
+            self.node.network.register(node_id, peer)
 
     # messaging -----------------------------------------------------------
     def send_hello(self) -> None:
         """Broadcast a HELLO message announcing this node."""
 
         self.node.send_message(
-            {"type": PeerDiscoveryMessageType.HELLO, "sender": self.node.node_id}
+            {
+                "type": PeerDiscoveryMessageType.HELLO,
+                "sender": self.node.node_id,
+                "host": self.host,
+                "port": self.port,
+            }
         )
 
     def send_peers(self) -> None:
@@ -74,7 +116,10 @@ class PeerDiscovery:
             {
                 "type": PeerDiscoveryMessageType.PEERS,
                 "sender": self.node.node_id,
-                "peers": list(self.known_peers),
+                "peers": [
+                    {"node_id": nid, **asdict(info)}
+                    for nid, info in self.known_peers.items()
+                ],
             }
         )
 
@@ -82,7 +127,12 @@ class PeerDiscovery:
         """Broadcast a PING message."""
 
         self.node.send_message(
-            {"type": PeerDiscoveryMessageType.PING, "sender": self.node.node_id}
+            {
+                "type": PeerDiscoveryMessageType.PING,
+                "sender": self.node.node_id,
+                "host": self.host,
+                "port": self.port,
+            }
         )
 
     def handle_message(self, message: Dict[str, Any]) -> None:
@@ -94,21 +144,50 @@ class PeerDiscovery:
             return
 
         if msg_type == PeerDiscoveryMessageType.HELLO:
-            if sender:
-                self.known_peers.add(sender)
+            host = message.get("host")
+            port = message.get("port")
+            if sender and host and isinstance(port, int):
+                self.known_peers[sender] = PeerInfo(host, int(port), time.time())
+                self._reconnect_peers()
             self.send_peers()
             self.save_peers()
         elif msg_type == PeerDiscoveryMessageType.PEERS:
             peers = message.get("peers", [])
             if isinstance(peers, list):
-                self.known_peers.update(peers)
+                for peer in peers:
+                    if not isinstance(peer, dict):
+                        continue
+                    node_id = peer.get("node_id")
+                    host = peer.get("host")
+                    port = peer.get("port")
+                    last_seen = peer.get("last_seen", time.time())
+                    if node_id and host and isinstance(port, int):
+                        self.known_peers[node_id] = PeerInfo(
+                            host, int(port), float(last_seen)
+                        )
+                self._reconnect_peers()
                 self.save_peers()
         elif msg_type == PeerDiscoveryMessageType.PING:
+            host = message.get("host")
+            port = message.get("port")
+            if sender and host and isinstance(port, int):
+                self.known_peers[sender] = PeerInfo(host, int(port), time.time())
+            elif sender in self.known_peers:
+                self.known_peers[sender].last_seen = time.time()
             self.node.send_message(
-                {"type": PeerDiscoveryMessageType.PONG, "sender": self.node.node_id}
+                {
+                    "type": PeerDiscoveryMessageType.PONG,
+                    "sender": self.node.node_id,
+                    "host": self.host,
+                    "port": self.port,
+                }
             )
+            self._reconnect_peers()
+            self.save_peers()
         elif msg_type == PeerDiscoveryMessageType.PONG:
-            pass
+            if sender in self.known_peers:
+                self.known_peers[sender].last_seen = time.time()
+                self.save_peers()
 
     # lifecycle -----------------------------------------------------------
     def start(self) -> None:
@@ -133,4 +212,4 @@ class PeerDiscovery:
             self.send_ping()
 
 
-__all__ = ["PeerDiscovery", "PeerDiscoveryMessageType"]
+__all__ = ["PeerDiscovery", "PeerDiscoveryMessageType", "PeerInfo"]


### PR DESCRIPTION
## Summary
- extend peer discovery to save host/port and timestamps
- automatically reload peers and reconnect on startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e032489fc83298fb7184b7b0b0215