### PR TITLE
Add debug logging to gossip handlers

### DIFF
--- a/helix/gossip.py
+++ b/helix/gossip.py
@@ -128,6 +128,8 @@ class GossipNode:
             if self._is_new(msg):
                 self._mark_seen(msg)
                 self._handle_presence(msg)
+                msg_type = msg.get("type")
+                print(f"{self.node_id} received message {msg_type}")
                 return msg
 
 

--- a/helix/peer_discovery.py
+++ b/helix/peer_discovery.py
@@ -90,6 +90,7 @@ class PeerDiscovery:
 
         msg_type = message.get("type")
         sender = message.get("sender")
+        print(f"peer_discovery received {msg_type} from {sender}")
         if sender == self.node.node_id:
             return
 
@@ -98,15 +99,18 @@ class PeerDiscovery:
                 self.known_peers.add(sender)
             self.send_peers()
             self.save_peers()
+            print("handled HELLO -> sent peers")
         elif msg_type == PeerDiscoveryMessageType.PEERS:
             peers = message.get("peers", [])
             if isinstance(peers, list):
                 self.known_peers.update(peers)
                 self.save_peers()
+            print("handled PEERS -> updated list")
         elif msg_type == PeerDiscoveryMessageType.PING:
             self.node.send_message(
                 {"type": PeerDiscoveryMessageType.PONG, "sender": self.node.node_id}
             )
+            print("handled PING -> sent PONG")
         elif msg_type == PeerDiscoveryMessageType.PONG:
             pass
 


### PR DESCRIPTION
## Summary
- print message type when a node receives a gossip message
- print peer discovery message handling actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e036627f0832999a156f264141971