### PR TITLE
Allow long nested seeds

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -187,6 +187,13 @@ def mark_mined(
 
 
 def accept_mined_seed(event: Dict[str, Any], index: int, seed_chain: List[bytes], *, miner: Optional[str] = None) -> float:
+    """Record ``seed_chain`` as the mining solution for ``microblock[index]``.
+
+    Only the first seed in ``seed_chain`` is validated against the microblock
+    size.  Nested seeds are merely checked for correctness via
+    :func:`nested_miner.verify_nested_seed`.
+    """
+
     seed = seed_chain[0]
     depth = len(seed_chain)
     block = event["microblocks"][index]

--- a/helix/nested_miner.py
+++ b/helix/nested_miner.py
@@ -36,13 +36,20 @@ def find_nested_seed(
 
 
 def verify_nested_seed(seed_chain: list[bytes], target_block: bytes) -> bool:
-    """Return ``True`` if applying ``G`` over ``seed_chain`` yields ``target_block``."""
+    """Return ``True`` if applying ``G`` over ``seed_chain`` yields ``target_block``.
+
+    Only ``seed_chain[0]`` is required to be ``<=`` the microblock size.  Subsequent
+    seeds may be any length as long as they match the result of applying ``G``.
+    """
 
     if not seed_chain:
         return False
 
     N = len(target_block)
-    current = seed_chain[0]
+    first = seed_chain[0]
+    if len(first) > N or len(first) == 0:
+        return False
+    current = first
     for next_seed in seed_chain[1:]:
         current = G(current, N)
         if current != next_seed:


### PR DESCRIPTION
## Summary
- clarify length rules in `verify_nested_seed`
- document outer seed validation in `accept_mined_seed`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1a50c0708329b97c2e42eb5118cc