### PR TITLE
Refactor nested seed encoding

### DIFF
--- a/helix/cli.py
+++ b/helix/cli.py
@@ -104,12 +104,14 @@ def cmd_mine(args: argparse.Namespace) -> None:
             if result is None:
                 # keep searching without aborting early
                 continue
-            chain, depth = result
-            if not nested_miner.verify_nested_seed(chain, block):
+            encoded, depth = result
+            if not nested_miner.verify_nested_seed(encoded, block):
                 continue
-            event_manager.accept_mined_seed(event, idx, chain)
+            event_manager.accept_mined_seed(event, idx, encoded)
+            _, seed_len = nested_miner.decode_header(encoded[0])
+            seed = encoded[1 : 1 + seed_len]
             print(
-                f"\u2714 Block {idx} mined at depth {depth} with seed {chain[0].hex()}"
+                f"\u2714 Block {idx} mined at depth {depth} with seed {seed.hex()}"
             )
             break
     event_manager.save_event(event, str(events_dir))
@@ -142,12 +144,12 @@ def cmd_remine_microblock(args: argparse.Namespace) -> None:
     if result is None:
         print(f"No seed found for block {index}")
         return
-    chain, depth = result
-    if not nested_miner.verify_nested_seed(chain, block):
+    encoded, depth = result
+    if not nested_miner.verify_nested_seed(encoded, block):
         print(f"Seed verification failed for block {index}")
         return
 
-    event_manager.accept_mined_seed(event, index, chain)
+    event_manager.accept_mined_seed(event, index, encoded)
     event_manager.save_event(event, str(events_dir))
     print(f"Remined microblock {index}")
 

--- a/helix/nested_miner.py
+++ b/helix/nested_miner.py
@@ -9,9 +9,27 @@ import random
 from .minihelix import G
 
 
+def encode_header(depth: int, seed_len: int) -> bytes:
+    """Return a single-byte header encoding ``depth`` and ``seed_len``."""
+    if not 1 <= depth <= 15:
+        raise ValueError("depth must be 1-15")
+    if not 1 <= seed_len <= 16:
+        raise ValueError("seed_len must be 1-16")
+    return bytes([(depth << 4) | (seed_len - 1)])
+
+
+def decode_header(b: int) -> tuple[int, int]:
+    """Decode ``b`` into ``(depth, seed_len)``."""
+    depth = (b >> 4) & 0x0F
+    seed_len = (b & 0x0F) + 1
+    if depth == 0 or seed_len < 1 or seed_len > 16:
+        raise ValueError("invalid header")
+    return depth, seed_len
+
+
 def find_nested_seed(
     target_block: bytes, max_depth: int = 3, *, attempts: int = 1_000_000
-) -> tuple[list[bytes], int] | None:
+) -> tuple[bytes, int] | None:
     """Search for a seed that produces ``target_block`` through nested ``G``.
 
     Returns a tuple of ``(seed_chain, depth)`` where ``seed_chain`` contains
@@ -28,25 +46,49 @@ def find_nested_seed(
         for depth in range(1, max_depth + 1):
             candidate = G(current, N)
             if candidate == target_block:
-                return chain, depth
+                header = encode_header(depth, len(chain[0]))
+                return header + b"".join(chain), depth
             if depth < max_depth:
                 chain.append(candidate)
                 current = candidate
     return None
 
 
-def verify_nested_seed(seed_chain: list[bytes], target_block: bytes) -> bool:
-    """Return ``True`` if applying ``G`` over ``seed_chain`` yields ``target_block``."""
+def verify_nested_seed(seed_chain: bytes, target_block: bytes) -> bool:
+    """Return ``True`` if ``seed_chain`` recreates ``target_block`` using nested ``G``."""
 
     if not seed_chain:
         return False
 
+    try:
+        depth, seed_len = decode_header(seed_chain[0])
+    except Exception:
+        return False
+
+    if seed_len >= len(target_block):
+        return False
+
+    if len(seed_chain) < 1 + seed_len:
+        return False
+
     N = len(target_block)
-    current = seed_chain[0]
-    for next_seed in seed_chain[1:]:
+    pos = 1
+    current = seed_chain[pos : pos + seed_len]
+    if len(current) != seed_len:
+        return False
+    pos += seed_len
+
+    for _ in range(1, depth):
         current = G(current, N)
-        if current != next_seed:
-            return False
+        if pos + N <= len(seed_chain):
+            next_seed = seed_chain[pos : pos + N]
+            if next_seed != current:
+                return False
+            pos += N
+
+    if len(seed_chain) not in {1 + seed_len, 1 + seed_len + (depth - 1) * N}:
+        return False
+
     current = G(current, N)
     return current == target_block
 
@@ -122,8 +164,9 @@ def mine_event_with_nested_parallel(
                 current = G(current, N)
                 for idx, target in list(targets):
                     if current == target:
+                        encoded = encode_header(depth, len(chain[0])) + b"".join(chain[:depth])
                         event_manager.accept_mined_seed(
-                            event, idx, chain[:depth], miner=miner_id
+                            event, idx, encoded, miner=miner_id
                         )
                         print(
                             f"\u2714 Mined block {idx} at depth {depth} (seed len {len(seed)})"
@@ -151,6 +194,8 @@ def mine_event_with_nested_parallel(
 __all__ = [
     "find_nested_seed",
     "verify_nested_seed",
+    "encode_header",
+    "decode_header",
     "hybrid_mine",
     "mine_event_with_nested_parallel",
 ]

--- a/tests/test_cli_mine_nested.py
+++ b/tests/test_cli_mine_nested.py
@@ -15,7 +15,7 @@ def test_cli_mine_nested(tmp_path, monkeypatch):
     event_manager.save_event(event, str(tmp_path / "events"))
     evt_id = event["header"]["statement_id"]
 
-    chain = [b"a", minihelix.G(b"a", 2)]
+    chain = event_manager.nested_miner.encode_header(2, 1) + b"a" + minihelix.G(b"a", 2)
     monkeypatch.setattr("helix.cli.nested_miner.find_nested_seed", lambda block: (chain, 2))
     monkeypatch.setattr("helix.cli.nested_miner.verify_nested_seed", lambda c, b: True)
 
@@ -24,4 +24,6 @@ def test_cli_mine_nested(tmp_path, monkeypatch):
     reloaded = event_manager.load_event(str(tmp_path / "events" / f"{evt_id}.json"))
     assert reloaded["is_closed"]
     assert reloaded["seed_depths"][0] == 2
-    assert reloaded["seeds"][0] == b"a"
+    hdr = reloaded["seeds"][0][0]
+    _, l = event_manager.nested_miner.decode_header(hdr)
+    assert reloaded["seeds"][0][1 : 1 + l] == b"a"

--- a/tests/test_cli_remine_microblock.py
+++ b/tests/test_cli_remine_microblock.py
@@ -12,7 +12,8 @@ def _mock_verify(monkeypatch):
 
 def _create_event(tmp_path):
     event = event_manager.create_event("abcdef", microblock_size=3)
-    event_manager.accept_mined_seed(event, 0, [b"long"])
+    encoded = event_manager.nested_miner.encode_header(1, len(b"long")) + b"long"
+    event_manager.accept_mined_seed(event, 0, encoded)
     event_manager.save_event(event, str(tmp_path / "events"))
     return event
 
@@ -22,7 +23,8 @@ def test_remine_requires_force(tmp_path, monkeypatch):
     evt_id = event["header"]["statement_id"]
 
     monkeypatch.setattr(
-        "helix.cli.nested_miner.find_nested_seed", lambda block: ([b"a"], 1)
+        "helix.cli.nested_miner.find_nested_seed",
+        lambda block: (event_manager.nested_miner.encode_header(1, 1) + b"a", 1),
     )
     monkeypatch.setattr(
         "helix.cli.nested_miner.verify_nested_seed", lambda chain, block: True
@@ -40,7 +42,9 @@ def test_remine_requires_force(tmp_path, monkeypatch):
         ]
     )
     reloaded = event_manager.load_event(str(tmp_path / "events" / f"{evt_id}.json"))
-    assert reloaded["seeds"][0] == b"long"
+    hdr = reloaded["seeds"][0][0]
+    _, l = event_manager.nested_miner.decode_header(hdr)
+    assert reloaded["seeds"][0][1 : 1 + l] == b"long"
 
 
 def test_remine_with_force(tmp_path, monkeypatch):
@@ -48,7 +52,8 @@ def test_remine_with_force(tmp_path, monkeypatch):
     evt_id = event["header"]["statement_id"]
 
     monkeypatch.setattr(
-        "helix.cli.nested_miner.find_nested_seed", lambda block: ([b"a"], 1)
+        "helix.cli.nested_miner.find_nested_seed",
+        lambda block: (event_manager.nested_miner.encode_header(1, 1) + b"a", 1),
     )
     monkeypatch.setattr(
         "helix.cli.nested_miner.verify_nested_seed", lambda chain, block: True
@@ -67,4 +72,6 @@ def test_remine_with_force(tmp_path, monkeypatch):
         ]
     )
     reloaded = event_manager.load_event(str(tmp_path / "events" / f"{evt_id}.json"))
-    assert reloaded["seeds"][0] == b"a"
+    hdr = reloaded["seeds"][0][0]
+    _, l = event_manager.nested_miner.decode_header(hdr)
+    assert reloaded["seeds"][0][1 : 1 + l] == b"a"

--- a/tests/test_compression_stats.py
+++ b/tests/test_compression_stats.py
@@ -15,7 +15,8 @@ def test_compression_stats(tmp_path):
     events_dir = tmp_path / "events"
     event = event_manager.create_event("abcd", microblock_size=2)
     for idx, block in enumerate(event["microblocks"]):
-        event_manager.accept_mined_seed(event, idx, [b"a"])
+        enc = event_manager.nested_miner.encode_header(1, 1) + b"a"
+        event_manager.accept_mined_seed(event, idx, enc)
     event_manager.save_event(event, str(events_dir))
 
     saved, hlx = compression_stats(str(events_dir))

--- a/tests/test_event_manager.py
+++ b/tests/test_event_manager.py
@@ -32,12 +32,15 @@ def test_event_closure():
 def test_accept_block_size_seed():
     event = em.create_event("ab", microblock_size=2)
     seed = b"xy"
-    refund = em.accept_mined_seed(event, 0, [seed])
+    encoded = em.nested_miner.encode_header(1, len(seed)) + seed
+    refund = em.accept_mined_seed(event, 0, encoded)
     assert refund == 0
-    assert event["seeds"][0] == seed
+    hdr = event["seeds"][0][0]
+    _, l = em.nested_miner.decode_header(hdr)
+    assert event["seeds"][0][1 : 1 + l] == seed
 
 
 def test_reject_oversize_seed():
     event = em.create_event("ab", microblock_size=2)
     with pytest.raises(ValueError):
-        em.accept_mined_seed(event, 0, [b"toolong"])
+        em.accept_mined_seed(event, 0, em.nested_miner.encode_header(1, 7) + b"toolong")

--- a/tests/test_minihelix.py
+++ b/tests/test_minihelix.py
@@ -44,10 +44,16 @@ def test_find_nested_seed_simple(monkeypatch):
 
     result = nested_miner.find_nested_seed(block, max_depth=3, attempts=1)
     assert result is not None, "find_nested_seed did not return a result"
-    chain, depth = result
-    print("Returned chain", chain, "depth", depth)
+    encoded, depth = result
+    print("Returned chain", encoded, "depth", depth)
     assert depth == 3, f"expected depth 3, got {depth}"
-    assert chain == [base_seed, inter1, inter2], "incorrect seed chain"
-    assert nested_miner.verify_nested_seed(chain, block), "seed chain failed verification"
+    expected = (
+        nested_miner.encode_header(3, len(base_seed))
+        + base_seed
+        + inter1
+        + inter2
+    )
+    assert encoded == expected, "incorrect seed encoding"
+    assert nested_miner.verify_nested_seed(encoded, block), "seed chain failed verification"
     print("Nested seed search SUCCESS")
 

--- a/tests/test_nested_miner.py
+++ b/tests/test_nested_miner.py
@@ -6,10 +6,9 @@ from helix import minihelix
 def test_verify_nested_seed():
     N = 8
     base_seed = b"seed"
-    chain = [base_seed]
-    intermediate = minihelix.G(base_seed, N)
-    chain.append(intermediate)
-    target = minihelix.G(intermediate, N)
+    inter = minihelix.G(base_seed, N)
+    chain = nested_miner.encode_header(2, len(base_seed)) + base_seed + inter
+    target = minihelix.G(inter, N)
     assert nested_miner.verify_nested_seed(chain, target)
 
 
@@ -31,6 +30,7 @@ def test_find_nested_seed_deterministic(monkeypatch):
 
     result = nested_miner.find_nested_seed(target, max_depth=2, attempts=1)
     assert result is not None
-    chain, depth = result
+    encoded, depth = result
     assert depth == 2
-    assert chain == [base_seed, intermediate]
+    expected = nested_miner.encode_header(2, len(base_seed)) + base_seed + intermediate
+    assert encoded == expected

--- a/tests/test_nesting_penalty.py
+++ b/tests/test_nesting_penalty.py
@@ -12,13 +12,14 @@ def _mock_verify(monkeypatch):
 
 def test_accept_mined_seed_replacement():
     event = event_manager.create_event("abc", microblock_size=3)
-    refund = event_manager.accept_mined_seed(event, 0, [b"a"])
+    enc = event_manager.nested_miner.encode_header(3, 1) + b"a"
+    refund = event_manager.accept_mined_seed(event, 0, enc)
     assert refund == 0
     assert event["seed_depths"][0] == 3
     assert event["penalties"][0] == 2
     original_reward = event["rewards"][0]
 
-    refund = event_manager.accept_mined_seed(event, 0, [b"a"])
+    refund = event_manager.accept_mined_seed(event, 0, enc)
     expected_reward = event_manager.reward_for_depth(2)
     assert refund == pytest.approx(original_reward - expected_reward)
     assert event["seed_depths"][0] == 2
@@ -29,12 +30,16 @@ def test_accept_mined_seed_replacement():
 
 def test_accept_mined_seed_shorter_replacement():
     event = event_manager.create_event("abc", microblock_size=3)
-    event_manager.accept_mined_seed(event, 0, [b"long", b"inter"])
+    enc_long = event_manager.nested_miner.encode_header(2, 4) + b"long" + b"inter"
+    event_manager.accept_mined_seed(event, 0, enc_long)
     original_reward = event["rewards"][0]
 
-    refund = event_manager.accept_mined_seed(event, 0, [b"a"])
+    enc_a = event_manager.nested_miner.encode_header(5, 1) + b"a"
+    refund = event_manager.accept_mined_seed(event, 0, enc_a)
     expected_reward = event_manager.reward_for_depth(5)
-    assert event["seeds"][0] == b"a"
+    hdr = event["seeds"][0][0]
+    _, l = event_manager.nested_miner.decode_header(hdr)
+    assert event["seeds"][0][1 : 1 + l] == b"a"
     assert event["seed_depths"][0] == 5
     assert refund == pytest.approx(original_reward - expected_reward)
     assert event["refunds"][0] == refund
@@ -42,16 +47,21 @@ def test_accept_mined_seed_shorter_replacement():
 
 def test_accept_mined_seed_conditions():
     event = event_manager.create_event("abc", microblock_size=3)
-    event_manager.accept_mined_seed(event, 0, [b"a"])
+    base = event_manager.nested_miner.encode_header(2, 1) + b"a"
+    event_manager.accept_mined_seed(event, 0, base)
     # different length should not replace
-    refund = event_manager.accept_mined_seed(event, 0, [b"bb"])
+    refund = event_manager.accept_mined_seed(event, 0, event_manager.nested_miner.encode_header(2, 2) + b"bb")
     assert refund == 0
-    assert event["seeds"][0] == b"a"
+    hdr = event["seeds"][0][0]
+    _, l = event_manager.nested_miner.decode_header(hdr)
+    assert event["seeds"][0][1 : 1 + l] == b"a"
     # higher depth should not replace
-    refund = event_manager.accept_mined_seed(event, 0, [b"c"])
+    refund = event_manager.accept_mined_seed(event, 0, event_manager.nested_miner.encode_header(3, 1) + b"c")
     assert refund == 0
     assert event["seed_depths"][0] == 2
     # same depth should not replace
-    refund = event_manager.accept_mined_seed(event, 0, [b"d"])
+    refund = event_manager.accept_mined_seed(event, 0, event_manager.nested_miner.encode_header(2, 1) + b"d")
     assert refund == 0
-    assert event["seeds"][0] == b"a"
+    hdr = event["seeds"][0][0]
+    _, l = event_manager.nested_miner.decode_header(hdr)
+    assert event["seeds"][0][1 : 1 + l] == b"a"

--- a/tests/test_simulate_mining.py
+++ b/tests/test_simulate_mining.py
@@ -17,7 +17,8 @@ def test_simulated_mining():
         seed = minihelix.mine_seed(block, max_attempts=100000)
         assert seed is not None
         assert minihelix.verify_seed(seed, block)
-        event_manager.accept_mined_seed(event, idx, [seed])
+        enc = event_manager.nested_miner.encode_header(1, len(seed)) + seed
+        event_manager.accept_mined_seed(event, idx, enc)
     assert event["is_closed"]
     final = event_manager.reassemble_microblocks(event["microblocks"])
     assert final == statement


### PR DESCRIPTION
## Summary
- add encode_header/decode_header helpers
- store nested seeds using compact header format
- refactor CLI and node mining code for new encoded seeds
- update accept_mined_seed to verify new format
- adjust tests for header-based encoding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1c7270a48329851266d7af4c833e