### PR TITLE
Refactor verify_nested_seed in nested_miner

### DIFF
--- a/helix/nested_miner.py
+++ b/helix/nested_miner.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from .minihelix import G
+
+
 def find_nested_seed(
     target_block: bytes,
     max_depth: int = 10,
@@ -37,3 +42,30 @@ def find_nested_seed(
                 chain.append(current)
         nonce += 1
     return None
+
+
+def verify_nested_seed(seed_chain: list[bytes], target_block: bytes) -> bool:
+    """Return True if applying G() iteratively over ``seed_chain`` yields ``target_block``.
+
+    Only ``seed_chain[0]`` is required to be ``<=`` the target block length.
+    Inner seeds may be any length.
+    """
+
+    if not seed_chain:
+        return False
+
+    N = len(target_block)
+
+    first = seed_chain[0]
+    if len(first) > N or len(first) == 0:
+        return False
+
+    current = first
+    for next_seed in seed_chain[1:]:
+        current = G(current, N)
+        if current != next_seed:
+            return False
+
+    # Final application of G must yield the target block
+    current = G(current, N)
+    return current == target_block


### PR DESCRIPTION
## Summary
- add missing import for MiniHelix `G`
- implement `verify_nested_seed` that checks each step of a nested seed chain

## Testing
- `pytest -q` *(fails: module 'helix.nested_miner' has no attribute 'hybrid_mine')*

------
https://chatgpt.com/codex/tasks/task_e_684e28636244832982b21f19e49a0cad