### PR TITLE
Implement Merkle tree support and miner utilities

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -58,6 +58,34 @@ def reassemble_microblocks(blocks: List[bytes]) -> str:
     payload = b"".join(blocks).rstrip(FINAL_BLOCK_PADDING_BYTE)
     return payload.decode("utf-8")
 
+def build_merkle_tree(blocks: List[bytes]) -> Tuple[str, List[List[str]]]:
+    """Return the Merkle root and full tree for ``blocks``.
+
+    Leaves are SHA-256 hashes of each microblock. Each parent node is the
+    SHA-256 hash of the concatenated child hashes. When a level has an odd
+    number of nodes, the last hash is duplicated.
+    """
+
+    if not blocks:
+        raise ValueError("no blocks to build merkle tree")
+
+    level: List[bytes] = [hashlib.sha256(b).digest() for b in blocks]
+    tree: List[List[bytes]] = [level]
+
+    while len(level) > 1:
+        if len(level) % 2 == 1:
+            level.append(level[-1])
+        next_level = [
+            hashlib.sha256(level[i] + level[i + 1]).digest()
+            for i in range(0, len(level), 2)
+        ]
+        tree.append(next_level)
+        level = next_level
+
+    root_hex = level[0].hex()
+    tree_hex: List[List[str]] = [[h.hex() for h in lvl] for lvl in tree]
+    return root_hex, tree_hex
+
 def create_event(
     statement: str,
     microblock_size: int = DEFAULT_MICROBLOCK_SIZE,
@@ -69,6 +97,7 @@ def create_event(
     microblocks, block_count, total_len = split_into_microblocks(
         statement, microblock_size
     )
+    merkle_root, merkle_tree = build_merkle_tree(microblocks)
     statement_id = sha256(statement.encode("utf-8"))
     if registry is not None:
         if registry.has_id(statement_id):
@@ -84,6 +113,7 @@ def create_event(
         "microblock_size": microblock_size,
         "block_count": block_count,
         "parent_id": parent_id,
+        "merkle_root": merkle_root,
     }
 
     originator_pub: Optional[str] = None
@@ -98,6 +128,7 @@ def create_event(
         "header": header,
         "statement": statement,
         "microblocks": microblocks,
+        "merkle_tree": merkle_tree,
         "mined_status": [False] * block_count,
         "seeds": [None] * block_count,
         "seed_depths": [0] * block_count,
@@ -243,6 +274,8 @@ def save_event(event: Dict[str, Any], directory: str) -> str:
     data["microblocks"] = [b.hex() for b in event["microblocks"]]
     if "seeds" in data:
         data["seeds"] = [s.hex() if isinstance(s, bytes) else None for s in data["seeds"]]
+    if "merkle_tree" in data:
+        data["merkle_tree"] = data["merkle_tree"]
     with open(filename, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
     return str(filename)
@@ -291,6 +324,12 @@ def load_event(path: str) -> Dict[str, Any]:
     data["microblocks"] = [bytes.fromhex(b) for b in data.get("microblocks", [])]
     if "seeds" in data:
         data["seeds"] = [bytes.fromhex(s) if isinstance(s, str) and s else None for s in data["seeds"]]
+    if "merkle_tree" not in data and data.get("microblocks"):
+        root, tree = build_merkle_tree(data["microblocks"])
+        data["merkle_tree"] = tree
+        if "header" in data:
+            data["header"].setdefault("merkle_root", root)
+    block_count = len(data.get("microblocks", []))
     block_count = len(data.get("microblocks", []))
     data.setdefault("seed_depths", [0] * block_count)
     data.setdefault("penalties", [0] * block_count)
@@ -304,6 +343,7 @@ __all__ = [
     "FINAL_BLOCK_PADDING_BYTE",
     "split_into_microblocks",
     "reassemble_microblocks",
+    "build_merkle_tree",
     "create_event",
     "mark_mined",
     "nesting_penalty",

--- a/helix/nested_miner.py
+++ b/helix/nested_miner.py
@@ -3,13 +3,43 @@ from __future__ import annotations
 from .minihelix import G
 
 
+def encode_header(depth: int, seed_len: int) -> bytes:
+    """Pack ``depth`` and ``seed_len`` into a single byte."""
+    if not (1 <= depth <= 15 and 1 <= seed_len <= 15):
+        raise ValueError("depth and seed_len must be between 1 and 15")
+    return bytes([(depth << 4) | seed_len])
+
+
+def decode_header(b: int | bytes) -> tuple[int, int]:
+    """Return ``(depth, seed_len)`` encoded by ``encode_header``."""
+    if isinstance(b, (bytes, bytearray)):
+        if not b:
+            raise ValueError("empty header")
+        b = b[0]
+    depth = (b >> 4) & 0x0F
+    seed_len = b & 0x0F
+    return depth, seed_len
+
+
+def _decode_chain(encoded: bytes, target_size: int) -> list[bytes]:
+    depth, seed_len = decode_header(encoded[0])
+    offset = 1
+    first = encoded[offset : offset + seed_len]
+    offset += seed_len
+    chain = [first]
+    for _ in range(1, depth):
+        chain.append(encoded[offset : offset + target_size])
+        offset += target_size
+    return chain
+
+
 def find_nested_seed(
     target_block: bytes,
     max_depth: int = 10,
     *,
     start_nonce: int = 0,
     attempts: int = 10_000,
-) -> tuple[list[bytes], int] | None:
+) -> tuple[bytes, int] | None:
     """Deterministically search for a nested seed chain yielding ``target_block``.
 
     Seeds are enumerated in increasing length starting at one byte. ``start_nonce``
@@ -19,7 +49,7 @@ def find_nested_seed(
     """
 
     def _seed_from_nonce(nonce: int, max_len: int) -> bytes | None:
-        for length in range(1, max_len):
+        for length in range(1, max_len + 1):
             count = 256 ** length
             if nonce < count:
                 return nonce.to_bytes(length, "big")
@@ -37,35 +67,55 @@ def find_nested_seed(
         for depth in range(1, max_depth + 1):
             current = G(current, N)
             if current == target_block:
-                return chain, depth
+                encoded = encode_header(depth, len(seed)) + b"".join(chain)
+                return encoded, depth
             if depth < max_depth:
                 chain.append(current)
         nonce += 1
     return None
 
 
-def verify_nested_seed(seed_chain: list[bytes], target_block: bytes) -> bool:
-    """Return True if applying G() iteratively over ``seed_chain`` yields ``target_block``.
-
-    Only ``seed_chain[0]`` is required to be ``<=`` the target block length.
-    Inner seeds may be any length.
-    """
+def verify_nested_seed(seed_chain: bytes | list[bytes], target_block: bytes) -> bool:
+    """Return ``True`` if ``seed_chain`` yields ``target_block`` under iterative ``G``."""
 
     if not seed_chain:
         return False
 
     N = len(target_block)
 
-    first = seed_chain[0]
+    if isinstance(seed_chain, (bytes, bytearray)):
+        chain = _decode_chain(seed_chain, N)
+    else:
+        chain = list(seed_chain)
+
+    first = chain[0]
     if len(first) > N or len(first) == 0:
         return False
 
     current = first
-    for next_seed in seed_chain[1:]:
+    for next_seed in chain[1:]:
         current = G(current, N)
         if current != next_seed:
             return False
 
-    # Final application of G must yield the target block
     current = G(current, N)
     return current == target_block
+
+
+def hybrid_mine(target_block: bytes, max_depth: int = 10) -> tuple[bytes, int] | None:
+    """Return a seed and depth that generate ``target_block`` using nested mining."""
+    result = find_nested_seed(target_block, max_depth=max_depth)
+    if result is None:
+        return None
+    encoded, depth = result
+    chain = _decode_chain(encoded, len(target_block))
+    return chain[0], depth
+
+
+__all__ = [
+    "encode_header",
+    "decode_header",
+    "find_nested_seed",
+    "verify_nested_seed",
+    "hybrid_mine",
+]

--- a/tests/test_event_manager.py
+++ b/tests/test_event_manager.py
@@ -18,11 +18,14 @@ def test_split_and_reassemble():
     assert length == len(statement.encode("utf-8"))
     assert all(len(b) == 4 for b in blocks)
     assert em.reassemble_microblocks(blocks) == statement
+    merkle_root, tree = em.build_merkle_tree(blocks)
+    assert merkle_root == tree[-1][0]
 
 
 def test_event_closure():
     statement = "Closure test"
     event = em.create_event(statement, microblock_size=4)
+    assert "merkle_root" in event["header"]
     assert event["is_closed"] is False
     for i in range(event["header"]["block_count"]):
         em.mark_mined(event, i)

--- a/tests/test_statement_submission.py
+++ b/tests/test_statement_submission.py
@@ -16,9 +16,14 @@ def test_create_event_with_signature():
     header_hash = hashlib.sha256(statement.encode("utf-8")).hexdigest()
     assert event["header"]["statement_id"] == header_hash
     assert len(event["microblocks"]) == event["header"]["block_count"]
+    merkle_root, tree = em.build_merkle_tree(event["microblocks"])
+    assert event["header"]["merkle_root"] == merkle_root
+    assert event["merkle_tree"] == tree
     assert verify_event_signature(event)
 
 
 def test_create_event_without_signature():
     event = em.create_event("No sig", microblock_size=4)
+    assert "merkle_root" in event["header"]
+    assert isinstance(event.get("merkle_tree"), list)
     assert not verify_event_signature(event)


### PR DESCRIPTION
## Summary
- generate a Merkle tree for uncompressed microblocks
- store the Merkle root in event headers and persist the tree off-chain
- add encoding utilities in `nested_miner` for seed chains
- update tests for new Merkle tree functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f017403508329a8b57faa6faeb33b