### PR TITLE
Implement Merkle utilities and nested miner helpers

### DIFF
--- a/helix/merkle_utils.py
+++ b/helix/merkle_utils.py
@@ -1,0 +1,63 @@
+import hashlib
+from typing import List, Tuple
+
+
+def _hash(data: bytes) -> bytes:
+    """Return SHA256 digest of ``data``."""
+    return hashlib.sha256(data).digest()
+
+
+def build_merkle_tree(microblocks: List[bytes]) -> Tuple[bytes, List[List[bytes]]]:
+    """Return the Merkle root and tree for ``microblocks``.
+
+    ``tree`` is a list of levels from leaves up to the root.  Each level
+    is a list of hashes.  The final level contains a single element which
+    is the Merkle root.
+    """
+    if not microblocks:
+        return b"", []
+
+    level: List[bytes] = [_hash(b) for b in microblocks]
+    tree: List[List[bytes]] = [level]
+
+    while len(level) > 1:
+        next_level: List[bytes] = []
+        for i in range(0, len(level), 2):
+            left = level[i]
+            right = level[i + 1] if i + 1 < len(level) else left
+            next_level.append(_hash(left + right))
+        tree.append(next_level)
+        level = next_level
+
+    root = level[0]
+    return root, tree
+
+
+def generate_merkle_proof(index: int, tree: List[List[bytes]]) -> List[bytes]:
+    """Return the Merkle proof for the leaf at ``index`` using ``tree``."""
+    proof: List[bytes] = []
+    for level in tree[:-1]:
+        sibling_idx = index ^ 1
+        if sibling_idx < len(level):
+            proof.append(level[sibling_idx])
+        index //= 2
+    return proof
+
+
+def verify_merkle_proof(leaf: bytes, proof: List[bytes], root: bytes, index: int) -> bool:
+    """Return True if ``proof`` authenticates ``leaf`` against ``root``."""
+    computed = _hash(leaf)
+    for sibling in proof:
+        if index % 2 == 0:
+            computed = _hash(computed + sibling)
+        else:
+            computed = _hash(sibling + computed)
+        index //= 2
+    return computed == root
+
+
+__all__ = [
+    "build_merkle_tree",
+    "generate_merkle_proof",
+    "verify_merkle_proof",
+]

--- a/helix/nested_miner.py
+++ b/helix/nested_miner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from . import minihelix
 from .minihelix import G
 
 
@@ -9,7 +10,7 @@ def find_nested_seed(
     *,
     start_nonce: int = 0,
     attempts: int = 10_000,
-) -> tuple[list[bytes], int] | None:
+) -> tuple[bytes, int] | None:
     """Deterministically search for a nested seed chain yielding ``target_block``.
 
     Seeds are enumerated in increasing length starting at one byte. ``start_nonce``
@@ -19,7 +20,7 @@ def find_nested_seed(
     """
 
     def _seed_from_nonce(nonce: int, max_len: int) -> bytes | None:
-        for length in range(1, max_len):
+        for length in range(1, max_len + 1):
             count = 256 ** length
             if nonce < count:
                 return nonce.to_bytes(length, "big")
@@ -32,40 +33,98 @@ def find_nested_seed(
         seed = _seed_from_nonce(nonce, N)
         if seed is None:
             return None
-        chain = [seed]
+        chain: list[bytes] = [seed]
         current = seed
         for depth in range(1, max_depth + 1):
             current = G(current, N)
             if current == target_block:
-                return chain, depth
+                header = encode_header(depth, len(seed))
+                return header + b"".join(chain), depth
             if depth < max_depth:
                 chain.append(current)
         nonce += 1
     return None
 
 
-def verify_nested_seed(seed_chain: list[bytes], target_block: bytes) -> bool:
-    """Return True if applying G() iteratively over ``seed_chain`` yields ``target_block``.
+def verify_nested_seed(seed_chain: list[bytes] | bytes, target_block: bytes) -> bool:
+    """Return ``True`` if ``seed_chain`` regenerates ``target_block``.
 
-    Only ``seed_chain[0]`` is required to be ``<=`` the target block length.
-    Inner seeds may be any length.
+    ``seed_chain`` may be either the raw byte encoding produced by
+    :func:`find_nested_seed` or a list of individual seeds.
     """
 
-    if not seed_chain:
+    if isinstance(seed_chain, bytes):
+        if not seed_chain:
+            return False
+        depth, seed_len = decode_header(seed_chain[0])
+        offset = 1
+        first = seed_chain[offset : offset + seed_len]
+        if len(first) != seed_len:
+            return False
+        offset += seed_len
+        seeds = [first]
+        for _ in range(1, depth):
+            next_seed = seed_chain[offset : offset + len(target_block)]
+            if len(next_seed) != len(target_block):
+                return False
+            seeds.append(next_seed)
+            offset += len(target_block)
+        if offset != len(seed_chain):
+            return False
+    else:
+        seeds = list(seed_chain)
+
+    if not seeds:
         return False
 
     N = len(target_block)
-
-    first = seed_chain[0]
-    if len(first) > N or len(first) == 0:
+    first = seeds[0]
+    if len(first) == 0 or len(first) > N:
         return False
 
     current = first
-    for next_seed in seed_chain[1:]:
+    for nxt in seeds[1:]:
         current = G(current, N)
-        if current != next_seed:
+        if current != nxt:
             return False
 
-    # Final application of G must yield the target block
     current = G(current, N)
     return current == target_block
+
+
+def encode_header(depth: int, seed_length: int) -> bytes:
+    """Encode ``depth`` and ``seed_length`` into a single byte."""
+    if depth < 1 or depth > 15:
+        raise ValueError("depth must be between 1 and 15")
+    if seed_length < 0 or seed_length > 15:
+        raise ValueError("seed_length must be between 0 and 15")
+    return bytes([(depth << 4) | (seed_length & 0x0F)])
+
+
+def decode_header(value: int | bytes) -> tuple[int, int]:
+    """Decode a header byte produced by :func:`encode_header`."""
+    if isinstance(value, bytes):
+        if len(value) != 1:
+            raise ValueError("header must be a single byte")
+        value = value[0]
+    depth = (value >> 4) & 0x0F
+    seed_length = value & 0x0F
+    return depth, seed_length
+
+
+def hybrid_mine(target_block: bytes, max_depth: int = 10, *, attempts: int = 1_000_000) -> tuple[bytes, int] | None:
+    """Search for a nested seed and return the base seed and depth."""
+    result = find_nested_seed(target_block, max_depth=max_depth, attempts=attempts)
+    if result is None:
+        return None
+    encoded, depth = result
+    d, seed_len = decode_header(encoded[0])
+    seed = encoded[1:1 + seed_len]
+    return seed, depth
+__all__ = [
+    "find_nested_seed",
+    "verify_nested_seed",
+    "encode_header",
+    "decode_header",
+    "hybrid_mine",
+]


### PR DESCRIPTION
## Summary
- add `merkle_utils` module providing Merkle tree building and proofs
- extend `nested_miner` with encode/decode header, hybrid mining and proof helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f018b5f748329a3eb99731b1ab283