### PR TITLE
Add integrity check during event finalization

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -118,6 +118,30 @@ def finalize_event(event: Dict[str, Any]) -> Dict[str, float]:
     Returns a mapping of participant pubkeys to payout amounts which is also
     stored in ``event['payouts']``.
     """
+    seeds = event.get("seeds", [])
+    blocks = event.get("microblocks", [])
+    if len(seeds) == len(blocks) and all(seeds):
+        recombined: List[bytes] = []
+        for idx, (enc, block) in enumerate(zip(seeds, blocks)):
+            if not nested_miner.verify_nested_seed(enc, block):
+                raise ValueError(f"invalid seed chain for microblock {idx}")
+            depth, seed_len = nested_miner.decode_header(enc[0])
+            offset = 1
+            seed = enc[offset : offset + seed_len]
+            offset += seed_len
+            current = seed
+            for _ in range(1, depth):
+                next_seed = enc[offset : offset + len(block)]
+                offset += len(block)
+                current = nested_miner.G(current, len(block))
+                current = next_seed
+            final_block = nested_miner.G(current, len(block))
+            recombined.append(final_block)
+        statement = reassemble_microblocks(recombined)
+        digest = sha256(statement.encode("utf-8"))
+        if digest != event.get("header", {}).get("statement_id"):
+            raise ValueError("final statement hash mismatch")
+
     yes_raw = event.get("bets", {}).get("YES", [])
     no_raw = event.get("bets", {}).get("NO", [])
 

--- a/helix/nested_miner.py
+++ b/helix/nested_miner.py
@@ -3,6 +3,32 @@ from __future__ import annotations
 from .minihelix import G
 
 
+def encode_header(depth: int, seed_len: int) -> bytes:
+    """Return a single byte encoding ``depth`` and ``seed_len``.
+
+    The high nibble stores ``depth`` and the low nibble stores ``seed_len``.
+    Both values must be in the range 1-15.
+    """
+
+    if depth < 1 or depth > 15:
+        raise ValueError("depth must be between 1 and 15")
+    if seed_len < 1 or seed_len > 15:
+        raise ValueError("seed_len must be between 1 and 15")
+    return bytes([(depth << 4) | seed_len])
+
+
+def decode_header(header: int | bytes) -> tuple[int, int]:
+    """Decode ``header`` produced by :func:`encode_header`."""
+
+    if isinstance(header, (bytes, bytearray)):
+        if len(header) != 1:
+            raise ValueError("header must be a single byte")
+        header = header[0]
+    depth = (header >> 4) & 0xF
+    seed_len = header & 0xF
+    return depth, seed_len
+
+
 def find_nested_seed(
     target_block: bytes,
     max_depth: int = 10,
@@ -16,10 +42,14 @@ def find_nested_seed(
     selects the offset into this enumeration and ``attempts`` controls how many
     seeds are tested. The outermost seed length is always strictly less than the
     target size while intermediate seeds may be any length.
+
+    Returns an encoded seed chain and its depth on success.  The encoding
+    begins with :func:`encode_header` followed by the outer seed and any
+    intermediate seeds.
     """
 
     def _seed_from_nonce(nonce: int, max_len: int) -> bytes | None:
-        for length in range(1, max_len):
+        for length in range(1, max_len + 1):
             count = 256 ** length
             if nonce < count:
                 return nonce.to_bytes(length, "big")
@@ -37,35 +67,65 @@ def find_nested_seed(
         for depth in range(1, max_depth + 1):
             current = G(current, N)
             if current == target_block:
-                return chain, depth
+                header = encode_header(depth, len(seed))
+                encoded = header + b"".join(chain)
+                return encoded, depth
             if depth < max_depth:
                 chain.append(current)
         nonce += 1
     return None
 
 
-def verify_nested_seed(seed_chain: list[bytes], target_block: bytes) -> bool:
-    """Return True if applying G() iteratively over ``seed_chain`` yields ``target_block``.
-
-    Only ``seed_chain[0]`` is required to be ``<=`` the target block length.
-    Inner seeds may be any length.
-    """
-
-    if not seed_chain:
+def _verify_chain(chain: list[bytes], target_block: bytes) -> bool:
+    if not chain:
         return False
 
     N = len(target_block)
-
-    first = seed_chain[0]
+    first = chain[0]
     if len(first) > N or len(first) == 0:
         return False
 
     current = first
-    for next_seed in seed_chain[1:]:
+    for next_seed in chain[1:]:
         current = G(current, N)
         if current != next_seed:
             return False
 
-    # Final application of G must yield the target block
     current = G(current, N)
     return current == target_block
+
+
+def verify_nested_seed(seed_chain: list[bytes] | bytes, target_block: bytes) -> bool:
+    """Return ``True`` if ``seed_chain`` regenerates ``target_block``."""
+
+    if isinstance(seed_chain, (bytes, bytearray)):
+        if not seed_chain:
+            return False
+        depth, seed_len = decode_header(seed_chain[0])
+        N = len(target_block)
+        needed = 1 + seed_len + N * (depth - 1)
+        if len(seed_chain) != needed:
+            return False
+        offset = 1
+        chain: list[bytes] = []
+        chain.append(seed_chain[offset : offset + seed_len])
+        offset += seed_len
+        for _ in range(1, depth):
+            chain.append(seed_chain[offset : offset + N])
+            offset += N
+        return _verify_chain(chain, target_block)
+
+    return _verify_chain(seed_chain, target_block)
+
+
+def hybrid_mine(target_block: bytes, max_depth: int = 10) -> tuple[bytes, int] | None:
+    """Search for a seed producing ``target_block`` and return the outer seed and depth."""
+
+    result = find_nested_seed(target_block, max_depth=max_depth)
+    if result is None:
+        return None
+
+    encoded, depth = result
+    _, seed_len = decode_header(encoded[0])
+    seed = encoded[1 : 1 + seed_len]
+    return seed, depth


### PR DESCRIPTION
## Summary
- support nested miner utilities (`encode_header`, `decode_header`, `hybrid_mine`)
- update `find_nested_seed` to return encoded seed chains
- verify microblock seeds when finalizing events
- fix deterministic mining for depth 1 targets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f018485188329bfa3cfe0ed479935