### PR TITLE
Update CLI output

### DIFF
--- a/helix/cli.py
+++ b/helix/cli.py
@@ -110,14 +110,13 @@ def cmd_mine(args: argparse.Namespace) -> None:
             offset += 10_000
             if result is None:
                 continue
-            encoded, depth = result
+            encoded, _depth = result
             if not nested_miner.verify_nested_seed(encoded, block):
                 continue
             event_manager.accept_mined_seed(event, idx, encoded)
             _, seed_len = nested_miner.decode_header(encoded[0])
-            seed = encoded[1 : 1 + seed_len]
             print(
-                f"\u2714 Block {idx} mined at depth {depth} with seed {seed.hex()}"
+                f"\u2714 Block {idx} mined with seed length {seed_len}"
             )
             break
     event_manager.save_event(event, str(events_dir))
@@ -150,7 +149,7 @@ def cmd_remine_microblock(args: argparse.Namespace) -> None:
     if result is None:
         print(f"No seed found for block {index}")
         return
-    encoded, depth = result
+    encoded, _depth = result
     if not nested_miner.verify_nested_seed(encoded, block):
         print(f"Seed verification failed for block {index}")
         return

--- a/helix/helix_cli.py
+++ b/helix/helix_cli.py
@@ -119,9 +119,9 @@ def cmd_reassemble_statement(args: argparse.Namespace) -> None:
 
     author = event.get("originator_pub")
     print(f"Author: {author}")
-    for idx, (depth, seed) in enumerate(zip(event.get("seed_depths", []), event.get("seeds", []))):
+    for idx, seed in enumerate(event.get("seeds", [])):
         length = len(seed) if seed is not None else 0
-        print(f"Block {idx}: depth={depth} seed_len={length}")
+        print(f"Block {idx}: seed_len={length}")
     print(statement)
 
 


### PR DESCRIPTION
## Summary
- hide mined depth information in CLI output
- show only seed length when printing block info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0a92e5b08329983b486bf33f270a