### PR TITLE
Refactor nested_miner API

### DIFF
--- a/helix/cli.py
+++ b/helix/cli.py
@@ -110,12 +110,12 @@ def cmd_mine(args: argparse.Namespace) -> None:
             offset += 10_000
             if result is None:
                 continue
-            encoded, depth = result
-            if not nested_miner.verify_nested_seed(encoded, block):
+            chain = result
+            depth = len(chain)
+            if not nested_miner.verify_nested_seed(chain, block):
                 continue
-            event_manager.accept_mined_seed(event, idx, encoded)
-            _, seed_len = nested_miner.decode_header(encoded[0])
-            seed = encoded[1 : 1 + seed_len]
+            event_manager.accept_mined_seed(event, idx, chain)
+            seed = chain[0]
             print(
                 f"\u2714 Block {idx} mined at depth {depth} with seed {seed.hex()}"
             )
@@ -150,12 +150,13 @@ def cmd_remine_microblock(args: argparse.Namespace) -> None:
     if result is None:
         print(f"No seed found for block {index}")
         return
-    encoded, depth = result
-    if not nested_miner.verify_nested_seed(encoded, block):
+    chain = result
+    depth = len(chain)
+    if not nested_miner.verify_nested_seed(chain, block):
         print(f"Seed verification failed for block {index}")
         return
 
-    event_manager.accept_mined_seed(event, index, encoded)
+    event_manager.accept_mined_seed(event, index, chain)
     event_manager.save_event(event, str(events_dir))
     print(f"Remined microblock {index}")
 

--- a/tests/test_cli_mine_nested.py
+++ b/tests/test_cli_mine_nested.py
@@ -15,14 +15,13 @@ def test_cli_mine_nested(tmp_path, monkeypatch):
     event_manager.save_event(event, str(tmp_path / "events"))
     evt_id = event["header"]["statement_id"]
 
-    header = event_manager.nested_miner.encode_header(2, 1)
     seed = b"a"
     subseed = minihelix.G(seed, 2)
-    chain = header + seed + subseed
+    chain = [seed, subseed]
 
     monkeypatch.setattr(
         "helix.cli.nested_miner.find_nested_seed",
-        lambda block, **kwargs: (chain, 2),
+        lambda block, **kwargs: chain,
     )
     monkeypatch.setattr("helix.cli.nested_miner.verify_nested_seed", lambda c, b: True)
 
@@ -31,6 +30,4 @@ def test_cli_mine_nested(tmp_path, monkeypatch):
     reloaded = event_manager.load_event(str(tmp_path / "events" / f"{evt_id}.json"))
     assert reloaded["is_closed"]
     assert reloaded["seed_depths"][0] == 2
-    hdr = reloaded["seeds"][0][0]
-    _, l = event_manager.nested_miner.decode_header(hdr)
-    assert reloaded["seeds"][0][1 : 1 + l] == b"a"
+    assert reloaded["seeds"][0][0] == b"a"

--- a/tests/test_compression_stats.py
+++ b/tests/test_compression_stats.py
@@ -15,8 +15,7 @@ def test_compression_stats(tmp_path):
     events_dir = tmp_path / "events"
     event = event_manager.create_event("abcd", microblock_size=2)
     for idx, block in enumerate(event["microblocks"]):
-        enc = event_manager.nested_miner.encode_header(1, 1) + b"a"
-        event_manager.accept_mined_seed(event, idx, enc)
+        event_manager.accept_mined_seed(event, idx, [b"a"])
     event_manager.save_event(event, str(events_dir))
 
     saved, hlx = compression_stats(str(events_dir))

--- a/tests/test_event_manager.py
+++ b/tests/test_event_manager.py
@@ -35,15 +35,13 @@ def test_event_closure():
 def test_accept_block_size_seed():
     event = em.create_event("ab", microblock_size=2)
     seed = b"xy"
-    encoded = em.nested_miner.encode_header(1, len(seed)) + seed
-    refund = em.accept_mined_seed(event, 0, encoded)
+    chain = [seed]
+    refund = em.accept_mined_seed(event, 0, chain)
     assert refund == 0
-    hdr = event["seeds"][0][0]
-    _, l = em.nested_miner.decode_header(hdr)
-    assert event["seeds"][0][1 : 1 + l] == seed
+    assert event["seeds"][0][0] == seed
 
 
 def test_reject_oversize_seed():
     event = em.create_event("ab", microblock_size=2)
     with pytest.raises(ValueError):
-        em.accept_mined_seed(event, 0, em.nested_miner.encode_header(1, 7) + b"toolong")
+        em.accept_mined_seed(event, 0, [b"toolong"])

--- a/tests/test_hybrid_miner.py
+++ b/tests/test_hybrid_miner.py
@@ -6,4 +6,4 @@ def test_hybrid_mine_simple():
     # Create a target that is two applications of G on the seed
     target = minihelix.G(minihelix.G(seed, N=1), N=1)
     result = nested_miner.hybrid_mine(target, max_depth=2)
-    assert result == (seed, 2)
+    assert result == [seed, minihelix.G(seed, N=1)]

--- a/tests/test_microblock_signature.py
+++ b/tests/test_microblock_signature.py
@@ -33,8 +33,8 @@ def test_signed_microblock_replacement(tmp_path):
     node_b.events[evt_id] = event_manager.create_event("ab", microblock_size=2)
 
     event_b = node_b.events[evt_id]
-    enc = event_manager.nested_miner.encode_header(3, len(b"long")) + b"long"
-    event_manager.accept_mined_seed(event_b, 0, enc)
+    chain_long = [b"long"]
+    event_manager.accept_mined_seed(event_b, 0, chain_long)
 
     seed = b"a"
     depth = 2
@@ -50,15 +50,11 @@ def test_signed_microblock_replacement(tmp_path):
         "signature": sig,
     }
     node_b._handle_message(msg)
-    hdr = event_b["seeds"][0][0]
-    _, l = event_manager.nested_miner.decode_header(hdr)
-    assert event_b["seeds"][0][1 : 1 + l] == seed
+    assert event_b["seeds"][0][0] == seed
     assert event_b["seed_depths"][0] == depth
 
     wrong = msg.copy()
     wrong["signature"] = signature_utils.sign_data(b"bad", priv)
     node_b._handle_message(wrong)
-    hdr = event_b["seeds"][0][0]
-    _, l = event_manager.nested_miner.decode_header(hdr)
-    assert event_b["seeds"][0][1 : 1 + l] == seed
+    assert event_b["seeds"][0][0] == seed
 

--- a/tests/test_minihelix.py
+++ b/tests/test_minihelix.py
@@ -45,16 +45,10 @@ def test_find_nested_seed_simple():
         block, max_depth=3, start_nonce=start_nonce, attempts=1
     )
     assert result is not None, "find_nested_seed did not return a result"
-    encoded, depth = result
-    print("Returned chain", encoded, "depth", depth)
-    assert depth == 3, f"expected depth 3, got {depth}"
-    expected = (
-        nested_miner.encode_header(3, len(base_seed))
-        + base_seed
-        + inter1
-        + inter2
-    )
-    assert encoded == expected, "incorrect seed encoding"
-    assert nested_miner.verify_nested_seed(encoded, block), "seed chain failed verification"
+    print("Returned chain", result)
+    assert len(result) == 3, f"expected depth 3, got {len(result)}"
+    expected = [base_seed, inter1, inter2]
+    assert result == expected, "incorrect seed chain"
+    assert nested_miner.verify_nested_seed(result, block), "seed chain failed verification"
     print("Nested seed search SUCCESS")
 

--- a/tests/test_nested_miner.py
+++ b/tests/test_nested_miner.py
@@ -7,7 +7,7 @@ def test_verify_nested_seed():
     N = 8
     base_seed = b"seed"
     inter = minihelix.G(base_seed, N)
-    chain = nested_miner.encode_header(2, len(base_seed)) + base_seed + inter
+    chain = [base_seed, inter]
     target = minihelix.G(inter, N)
     assert nested_miner.verify_nested_seed(chain, target)
 
@@ -32,7 +32,5 @@ def test_find_nested_seed_deterministic():
         target, max_depth=2, start_nonce=start_nonce, attempts=1
     )
     assert result is not None
-    encoded, depth = result
-    assert depth == 2
-    expected = nested_miner.encode_header(2, len(base_seed)) + base_seed + intermediate
-    assert encoded == expected
+    expected = [base_seed, intermediate]
+    assert result == expected

--- a/tests/test_simulate_mining.py
+++ b/tests/test_simulate_mining.py
@@ -17,8 +17,7 @@ def test_simulated_mining():
         seed = minihelix.mine_seed(block, max_attempts=100000)
         assert seed is not None
         assert minihelix.verify_seed(seed, block)
-        enc = event_manager.nested_miner.encode_header(1, len(seed)) + seed
-        event_manager.accept_mined_seed(event, idx, enc)
+        event_manager.accept_mined_seed(event, idx, [seed])
     assert event["is_closed"]
     final = event_manager.reassemble_microblocks(event["microblocks"])
     assert final == statement


### PR DESCRIPTION
## Summary
- remove header encoding helpers and depth return values
- update nested seed search to return a seed chain
- verify seeds by replaying the chain
- adjust hybrid miner and surrounding modules
- update tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0a7d816c8329ad93bc6f7c9fb638