### PR TITLE
Add blockchain state loading in HelixNode

### DIFF
--- a/helix/blockchain.py
+++ b/helix/blockchain.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def load_chain(path: str) -> List[Dict[str, Any]]:
+    """Load blockchain data from ``path``.
+
+    If the file does not exist, an empty list is returned.
+    The file is expected to contain JSON representing a list of blocks or a
+    dictionary with a ``"chain"`` key.
+    """
+    file = Path(path)
+    if not file.exists():
+        return []
+    with open(file, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if isinstance(data, dict):
+        data = data.get("chain", [])
+    if not isinstance(data, list):
+        return []
+    return data
+
+
+def validate_chain(chain: List[Dict[str, Any]]) -> bool:
+    """Basic validation of a blockchain structure.
+
+    Each block must be a dictionary containing at least an ``event_id`` field.
+    If a ``height`` field is present, it must match the block's index.
+    """
+    if not isinstance(chain, list):
+        return False
+    for idx, block in enumerate(chain):
+        if not isinstance(block, dict):
+            return False
+        if "event_id" not in block:
+            return False
+        if "height" in block and block["height"] != idx:
+            return False
+    return True
+
+
+__all__ = ["load_chain", "validate_chain"]

--- a/helix/helix_node.py
+++ b/helix/helix_node.py
@@ -55,6 +55,7 @@ class HelixNode(GossipNode):
         *,
         events_dir: str,
         balances_file: str,
+        chain_file: str | None = None,
         node_id: str = "NODE",
         network: LocalGossipNetwork | SocketGossipNetwork | None = None,
         microblock_size: int = event_manager.DEFAULT_MICROBLOCK_SIZE,
@@ -70,6 +71,9 @@ class HelixNode(GossipNode):
         self.events_dir = Path(events_dir)
         self.events_dir.mkdir(parents=True, exist_ok=True)
         self.balances_file = str(balances_file)
+        if chain_file is None:
+            chain_file = str(Path(balances_file).parent / "chain.json")
+        self.chain_file = str(chain_file)
         self.microblock_size = microblock_size
         self.max_nested_depth = max_nested_depth
         self.public_key = public_key
@@ -88,6 +92,31 @@ class HelixNode(GossipNode):
         self.balances: Dict[str, float] = load_balances(self.balances_file)
 
         self.load_state()
+
+        # Load blockchain and replay balances
+        from . import blockchain
+
+        self.chain: list[dict] = blockchain.load_chain(self.chain_file)
+        for block in self.chain:
+            evt_id = block.get("event_id")
+            if not evt_id:
+                continue
+            event = self.events.get(evt_id)
+            if event is None:
+                evt_path = self.events_dir / f"{evt_id}.json"
+                if not evt_path.exists():
+                    continue
+                try:
+                    event = event_manager.load_event(str(evt_path))
+                    self.import_event(event)
+                except Exception:
+                    continue
+            apply_mining_results(event, self.balances)
+
+        if blockchain.validate_chain(self.chain):
+            print("Blockchain loaded successfully")
+        else:
+            print("Blockchain validation mismatch")
 
     def _store_merkle_tree(self, event: Dict[str, Any]) -> None:
         evt_id = event["header"]["statement_id"]


### PR DESCRIPTION
## Summary
- add new `helix.blockchain` module for reading and validating a simple chain file
- extend `HelixNode` constructor to load a blockchain file
- replay stored mining rewards when loading nodes
- log validation success or failure

## Testing
- `pytest -q` *(fails: hybrid mining API mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_684f3983956083299573bcc637aad5f7