### PR TITLE
Add total supply tracking

### DIFF
--- a/helix/helix_node.py
+++ b/helix/helix_node.py
@@ -16,7 +16,12 @@ from . import (
     merkle,
 )
 from .config import GENESIS_HASH
-from .ledger import load_balances, save_balances, apply_mining_results
+from .ledger import (
+    load_balances,
+    save_balances,
+    apply_mining_results,
+    update_total_supply,
+)
 from .gossip import GossipNode, LocalGossipNetwork
 from .network import SocketGossipNetwork
 
@@ -210,6 +215,9 @@ class HelixNode(GossipNode):
             if pub:
                 self.balances[pub] = self.balances.get(pub, 0.0) + amt
         apply_mining_results(event, self.balances)
+        rewards = event.get("rewards", [])
+        refunds = event.get("refunds", [])
+        update_total_supply(sum(rewards) + sum(refunds))
         save_balances(self.balances, self.balances_file)
         event_manager.save_event(event, str(self.events_dir))
         self._send({"type": GossipMessageType.FINALIZED, "event_id": event["header"]["statement_id"]})

--- a/helix/ledger.py
+++ b/helix/ledger.py
@@ -21,6 +21,26 @@ def save_balances(balances: Dict[str, float], path: str) -> None:
         json.dump(balances, f, indent=2)
 
 
+def get_total_supply(path: str = "supply.json") -> float:
+    """Return total HLX supply stored in ``path``.
+
+    If the file does not exist, return ``0.0``.
+    """
+    file = Path(path)
+    if not file.exists():
+        return 0.0
+    with open(file, "r", encoding="utf-8") as f:
+        return float(json.load(f))
+
+
+def update_total_supply(delta: float, path: str = "supply.json") -> None:
+    """Increase total supply by ``delta`` and persist the new value."""
+    total = get_total_supply(path) + float(delta)
+    file = Path(path)
+    with open(file, "w", encoding="utf-8") as f:
+        json.dump(total, f)
+
+
 def compression_stats(events_dir: str) -> Tuple[int, float]:
     """Return total bytes saved and HLX earned across finalized events.
 
@@ -86,4 +106,6 @@ __all__ = [
     "save_balances",
     "compression_stats",
     "apply_mining_results",
+    "get_total_supply",
+    "update_total_supply",
 ]


### PR DESCRIPTION
## Summary
- track overall supply with helper functions
- update supply when finalizing events

## Testing
- `pytest -q` *(fails: hybrid miner, find nested seed, verify nested seed)*

------
https://chatgpt.com/codex/tasks/task_e_684f398f8f40832987e88798da3eef29