### PR TITLE
Add get_chain_tip helper

### DIFF
--- a/helix/blockchain.py
+++ b/helix/blockchain.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from .config import GENESIS_HASH
+
+
+def get_chain_tip(path: str = "blockchain.jsonl") -> str:
+    """Return the latest ``block_id`` from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Path to the blockchain JSON lines file.
+
+    Returns
+    -------
+    str
+        ``block_id`` of the last entry, or :data:`GENESIS_HASH` if the file is
+        missing or empty.
+    """
+    file = Path(path)
+    if not file.exists():
+        return GENESIS_HASH
+
+    last_line: str | None = None
+    with open(file, "r", encoding="utf-8") as fh:
+        for line in fh:
+            if line.strip():
+                last_line = line
+
+    if not last_line:
+        return GENESIS_HASH
+
+    try:
+        entry = json.loads(last_line)
+    except json.JSONDecodeError:
+        return GENESIS_HASH
+
+    return entry.get("block_id", GENESIS_HASH)
+
+
+__all__ = ["get_chain_tip"]


### PR DESCRIPTION
## Summary
- add `get_chain_tip` to retrieve the latest block id from a JSON-lines blockchain file

## Testing
- `pytest -q` *(fails: TypeError in nested miner tests)*

------
https://chatgpt.com/codex/tasks/task_e_684f39bbda10832982fb178b71f3ca1e