### PR TITLE
Add token-stats subcommand

### DIFF
--- a/helix/cli.py
+++ b/helix/cli.py
@@ -15,6 +15,7 @@ from . import event_manager
 from . import nested_miner
 from . import betting_interface
 from .ledger import load_balances, compression_stats
+from .ledger import get_total_supply
 
 
 def _default_genesis_file() -> str:
@@ -51,6 +52,12 @@ def cmd_status(args: argparse.Namespace) -> None:
 
 def _load_event(path: Path) -> dict:
     return event_manager.load_event(str(path))
+
+
+def cmd_token_stats(args: argparse.Namespace) -> None:
+    events_dir = Path(args.data_dir) / "events"
+    total = get_total_supply(str(events_dir))
+    print(f"Total HLX Issued: {total:.4f}")
 
 
 def cmd_start_node(args: argparse.Namespace) -> None:
@@ -363,6 +370,9 @@ def main(argv: list[str] | None = None) -> None:
 
     p_wallet = sub.add_parser("view-wallet", help="View wallet balances")
     p_wallet.set_defaults(func=cmd_view_wallet)
+
+    p_tstats = sub.add_parser("token-stats", help="Show total token supply")
+    p_tstats.set_defaults(func=cmd_token_stats)
 
     p_remine = sub.add_parser("remine-microblock", help="Retry mining a single microblock")
     p_remine.add_argument("--event-id", required=True, help="Event identifier")

--- a/helix/ledger.py
+++ b/helix/ledger.py
@@ -81,9 +81,26 @@ def apply_mining_results(event: Dict[str, Any], balances: Dict[str, float]) -> N
             balances[old_miner] = balances.get(old_miner, 0.0) + refund
 
 
+def get_total_supply(events_dir: str) -> float:
+    """Return total HLX issued across all events in ``events_dir``."""
+    path = Path(events_dir)
+    if not path.exists():
+        return 0.0
+
+    supply = 0.0
+    for event_file in path.glob("*.json"):
+        event = event_manager.load_event(str(event_file))
+        rewards = event.get("rewards", [])
+        refunds = event.get("refunds", [])
+        supply += sum(rewards) - sum(refunds)
+
+    return supply
+
+
 __all__ = [
     "load_balances",
     "save_balances",
     "compression_stats",
     "apply_mining_results",
+    "get_total_supply",
 ]

--- a/tests/test_cli_token_stats.py
+++ b/tests/test_cli_token_stats.py
@@ -1,0 +1,23 @@
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import cli, event_manager
+
+
+@pytest.fixture(autouse=True)
+def _mock_verify(monkeypatch):
+    monkeypatch.setattr(event_manager.nested_miner, "verify_nested_seed", lambda c, b: True)
+
+
+def test_cli_token_stats(tmp_path, capsys):
+    event = event_manager.create_event("abcd", microblock_size=2)
+    for idx, block in enumerate(event["microblocks"]):
+        event_manager.accept_mined_seed(event, idx, [b"a"])
+    event_manager.save_event(event, str(tmp_path / "events"))
+    capsys.readouterr()  # clear mark_mined output
+
+    cli.main(["--data-dir", str(tmp_path), "token-stats"])
+    out = capsys.readouterr().out.strip()
+    expected = sum(event["rewards"]) - sum(event["refunds"])
+    assert f"Total HLX Issued: {expected:.4f}" in out


### PR DESCRIPTION
## Summary
- implement `get_total_supply` in ledger
- update nested miner utilities to satisfy tests
- add `token-stats` subcommand to CLI
- test new command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3a5ef7088329b721fa84b51433e5