### PR TITLE
Add automatic finalization when mining completes

### DIFF
--- a/helix/nested_miner.py
+++ b/helix/nested_miner.py
@@ -111,4 +111,12 @@ def verify_nested_seed(
     if len(seed_chain) - 1 >= max_steps:
         return False
     current = seed_chain[0]
-    for step_num, step in enumerate(seed_chain[1:]()
+    for step_num, step in enumerate(seed_chain[1:], start=1):
+        if step_num > max_steps:
+            return False
+        current = G(current, N)
+        if current != step:
+            return False
+    current = G(current, N)
+    return current == target_block
+    


### PR DESCRIPTION
## Summary
- finalize events automatically when all microblocks are mined
- prevent duplicate finalization
- fix `verify_nested_seed` loop implementation

## Testing
- `pytest -q` *(fails: AttributeError in `hybrid_mine` and assertion in nested miner)*

------
https://chatgpt.com/codex/tasks/task_e_684f403f07548329b3debd7c67be75ca