### PR TITLE
Add chain validation function

### DIFF
--- a/helix/ledger.py
+++ b/helix/ledger.py
@@ -1,4 +1,3 @@
-```python
 import json
 from pathlib import Path
 from typing import Dict, Tuple, Any
@@ -130,4 +129,3 @@ __all__ = [
     "apply_mining_results",
     "get_total_supply",
 ]
-```


### PR DESCRIPTION
## Summary
- fix stray markdown markers in `helix.blockchain` and `helix.ledger`
- implement `validate_chain()` that validates block linkage and hashing

## Testing
- `pip install -q PyNaCl`
- `pytest -q` *(fails: invalid seed chain etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684f44bd1f508329b34640dcbbecb6fa