### PR TITLE
Implement compute_reward and miner payout

### DIFF
--- a/helix/helix_node.py
+++ b/helix/helix_node.py
@@ -214,7 +214,10 @@ class HelixNode(GossipNode):
             else:
                 result = nested_miner.find_nested_seed(block, max_depth=self.max_nested_depth)
                 if result:
-                    encoded, _ = result
+                    if isinstance(result, tuple):
+                        encoded, _ = result
+                    else:
+                        encoded = bytes(result)
                     chain = nested_miner._decode_chain(encoded, len(block))
                     if nested_miner.verify_nested_seed(chain, block):
                         seed_chain = chain


### PR DESCRIPTION
## Summary
- calculate HLX rewards via new `compute_reward` helper
- credit miner reward in `finalize_event`
- support nested seed mining with new return type
- implement `hybrid_mine` and adjust node mining logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f44d82df88329b1dc1f820a2fd1c8