### PR TITLE
Refactor finalize_event usage

### DIFF
--- a/tests/test_blockchain.py
+++ b/tests/test_blockchain.py
@@ -2,6 +2,7 @@ import sys
 import types
 import pytest
 import blockchain as bc
+import helix.blockchain as blockchain
 
 pytest.importorskip("nacl")
 
@@ -26,7 +27,7 @@ def test_finalize_appends_block(tmp_path, monkeypatch):
     assert event["is_closed"], "event should be closed once mined"
 
     before = bc.load_chain(str(chain_file))
-    em.finalize_event(event, node_id="NODE")
+    em.finalize_event(event, node_id="NODE", chain_file=str(chain_file), _bc=blockchain)
     after = bc.load_chain(str(chain_file))
 
     assert len(after) == len(before) + 1

--- a/tests/test_finalized_chain_sync.py
+++ b/tests/test_finalized_chain_sync.py
@@ -26,6 +26,7 @@ _load_clean_module("helix.blockchain", ROOT / "helix" / "blockchain.py")
 from helix.helix_node import HelixNode, GossipMessageType
 from helix.gossip import LocalGossipNetwork
 import blockchain as bc
+import helix.blockchain as blockchain
 import helix.blockchain as hbc
 import helix.event_manager as em
 
@@ -57,7 +58,12 @@ def test_finalized_block_sync(tmp_path, monkeypatch):
     monkeypatch.setattr(em.nested_miner, "verify_nested_seed", lambda c, b: True)
 
     def finalize_patch(event, *, node_id=None, chain_file=chain_file):
-        return orig_finalize(event, node_id=node_id, chain_file=str(chain_file))
+        return orig_finalize(
+            event,
+            node_id=node_id,
+            chain_file=str(chain_file),
+            _bc=blockchain,
+        )
 
     monkeypatch.setattr(em, "finalize_event", finalize_patch)
 

--- a/tests/test_genesis_chain.py
+++ b/tests/test_genesis_chain.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 import blockchain as bc
+import helix.blockchain as blockchain
 from helix.config import GENESIS_HASH
 
 pytest.importorskip("nacl")
@@ -31,7 +32,12 @@ def test_genesis_block_and_chain(tmp_path, monkeypatch):
         em.accept_mined_seed(genesis_event, idx, [b"a"])
     assert genesis_event["is_closed"]
 
-    em.finalize_event(genesis_event, node_id="GEN", chain_file=str(chain_file))
+    em.finalize_event(
+        genesis_event,
+        node_id="GEN",
+        chain_file=str(chain_file),
+        _bc=blockchain,
+    )
     chain = bc.load_chain(str(chain_file))
     assert len(chain) == 1
     first = chain[0]
@@ -45,7 +51,12 @@ def test_genesis_block_and_chain(tmp_path, monkeypatch):
         em.accept_mined_seed(ev, idx, [b"a"])
     assert ev["is_closed"]
 
-    em.finalize_event(ev, node_id="NODE", chain_file=str(chain_file))
+    em.finalize_event(
+        ev,
+        node_id="NODE",
+        chain_file=str(chain_file),
+        _bc=blockchain,
+    )
     chain = bc.load_chain(str(chain_file))
     assert len(chain) == 2
     second = chain[1]

--- a/tests/test_resolve_fork.py
+++ b/tests/test_resolve_fork.py
@@ -1,6 +1,7 @@
 import sys
 import types
 import blockchain as bc
+import helix.blockchain as blockchain
 
 import pytest
 
@@ -22,7 +23,12 @@ def _make_event(tmp_path, text, chain_file):
     event = em.create_event(text, microblock_size=len(text))
     enc = bytes([1, 1]) + b"a"
     em.accept_mined_seed(event, 0, enc)
-    em.finalize_event(event, node_id="X", chain_file=str(chain_file))
+    em.finalize_event(
+        event,
+        node_id="X",
+        chain_file=str(chain_file),
+        _bc=blockchain,
+    )
     em.save_event(event, str(tmp_path / "events"))
     return event
 


### PR DESCRIPTION
## Summary
- import `helix.blockchain` where missing
- forward `_bc` and `chain_file` when calling `finalize_event`
- update `HelixNode` to keep using old blockchain module as `bc`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4f396fb08329bf1e39bfda67b8b1