### PR TITLE
Add helix submit-statement command

### DIFF
--- a/helix/helix_cli.py
+++ b/helix/helix_cli.py
@@ -13,6 +13,7 @@ from .blockchain import load_chain
 
 EVENTS_DIR = Path("events")
 BALANCES_FILE = Path("balances.json")
+DATA_EVENTS_DIR = Path("data/events")
 
 
 def _load_event(event_id: str) -> dict:
@@ -34,18 +35,19 @@ def cmd_generate_keys(args: argparse.Namespace) -> None:
 
 
 def cmd_submit_statement(args: argparse.Namespace) -> None:
+    """Create an event from ``args.statement`` and store it on disk."""
     event = event_manager.create_event(
         args.statement,
-        microblock_size=args.microblock_size,
-        keyfile=args.keyfile,
+        microblock_size=args.block_size,
     )
 
-    network = LocalGossipNetwork()
-    node = GossipNode("CLI", network)
-    node.send_message({"type": "NEW_STATEMENT", "event": event})
+    path = event_manager.save_event(event, str(DATA_EVENTS_DIR))
 
-    print(f"Statement ID: {event['header']['statement_id']}")
-    print("Event submitted via gossip")
+    event_id = event["header"]["statement_id"]
+    block_count = event["header"]["block_count"]
+
+    print(f"Event ID: {event_id}")
+    print(f"Blocks created: {block_count}")
 
 
 def cmd_mine_statement(args: argparse.Namespace) -> None:
@@ -172,14 +174,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_submit = sub.add_parser("submit-statement", help="Submit a statement")
     p_submit.add_argument("statement", help="Statement text")
     p_submit.add_argument(
-        "--keyfile",
-        required=True,
-        help="File containing originator keys",
-    )
-    p_submit.add_argument(
-        "--microblock-size",
+        "--block-size",
         type=int,
-        default=4,
+        default=8,
         help="Microblock size in bytes",
     )
     p_submit.set_defaults(func=cmd_submit_statement)

--- a/tests/test_helix_cli_submit_statement.py
+++ b/tests/test_helix_cli_submit_statement.py
@@ -1,0 +1,22 @@
+import json
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import helix_cli
+
+
+def test_submit_statement(tmp_path, capsys, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    statement = "The Earth revolves around the Sun."
+    helix_cli.main(["submit-statement", statement, "--block-size", "8"])
+    out_lines = capsys.readouterr().out.strip().splitlines()
+    assert out_lines
+    event_id = out_lines[0].split()[-1] if len(out_lines[0].split()) > 1 else out_lines[0]
+    event_file = tmp_path / "data" / "events" / f"{event_id}.json"
+    assert event_file.exists()
+    with open(event_file, "r", encoding="utf-8") as f:
+        evt = json.load(f)
+    assert evt["header"]["block_count"] == len(evt["microblocks"])
+    assert int(out_lines[1].split()[-1]) == evt["header"]["block_count"]
+


### PR DESCRIPTION
## Summary
- implement `submit-statement` CLI command in `helix_cli`
- save created event to `./data/events/<event_id>.json`
- print new event id and number of blocks generated
- test CLI with temporary directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6b8275d88329b33f39f44ecd4056