### PR TITLE
Add event mining to helix CLI

### DIFF
--- a/tests/test_helix_cli_mine_event.py
+++ b/tests/test_helix_cli_mine_event.py
@@ -1,0 +1,30 @@
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import helix_cli, event_manager, helix_node
+
+
+@pytest.fixture(autouse=True)
+def _mock_verify(monkeypatch):
+    monkeypatch.setattr(event_manager.nested_miner, "verify_nested_seed", lambda c, b: True)
+
+
+def test_cli_mine_event(tmp_path, monkeypatch, capsys):
+    event = event_manager.create_event("ab", microblock_size=2)
+    event_manager.save_event(event, str(tmp_path / "events"))
+    evt_id = event["header"]["statement_id"]
+
+    def fake_mine(ev, max_depth=4):
+        enc = bytes([1, 1]) + b"a"
+        event_manager.accept_mined_seed(ev, 0, enc)
+        return 1, 0.0
+
+    monkeypatch.setattr(helix_node, "mine_microblocks", fake_mine)
+
+    helix_cli.main(["mine", evt_id, "--data-dir", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert "Blocks mined: 1" in out
+
+    reloaded = event_manager.load_event(str(tmp_path / "events" / f"{evt_id}.json"))
+    assert reloaded["is_closed"]


### PR DESCRIPTION
## Summary
- add `mine_microblocks` helper in `helix_node`
- implement `helix mine <event_id>` command
- test new CLI behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6b896bd88329b24040db517b4511