### PR TITLE
Add finalize CLI command

### DIFF
--- a/helix/helix_cli.py
+++ b/helix/helix_cli.py
@@ -165,6 +165,28 @@ def cmd_view_chain(args: argparse.Namespace) -> None:
             print(f"height={height} event_id={event_id} block_id={block_id} saved={saved}")
 
 
+def cmd_finalize(args: argparse.Namespace) -> None:
+    """Finalize an event and append the block to the chain."""
+    event = _load_event(args.event_id)
+
+    for idx, block in enumerate(event.get("microblocks", [])):
+        seed = event.get("seeds", [])[idx]
+        if seed is None:
+            raise SystemExit(f"Missing seed for block {idx}")
+        if not event_manager.nested_miner.verify_nested_seed(seed, block):
+            raise SystemExit(f"Seed verification failed for block {idx}")
+
+    statement = event_manager.reassemble_microblocks(event["microblocks"])
+    digest = event_manager.sha256(statement.encode("utf-8"))
+    expected = event.get("header", {}).get("statement_id")
+    if digest != expected:
+        raise SystemExit("SHA-256 mismatch")
+
+    event_manager.finalize_event(event)
+    _save_event(event)
+    print("statement verified, block saved, rewards distributed")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="helix")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -218,6 +240,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_chain.add_argument("--data-dir", default="data", help="Directory containing chain and events")
     p_chain.add_argument("--summary", action="store_true", help="Summary output")
     p_chain.set_defaults(func=cmd_view_chain)
+
+    p_fin = sub.add_parser("finalize", help="Finalize an event")
+    p_fin.add_argument("event_id", help="Event identifier")
+    p_fin.set_defaults(func=cmd_finalize)
 
     return parser
 

--- a/tests/test_helix_cli_finalize.py
+++ b/tests/test_helix_cli_finalize.py
@@ -1,0 +1,28 @@
+import pytest
+import blockchain as bc
+
+pytest.importorskip("nacl")
+
+from helix import helix_cli, event_manager
+
+
+@pytest.fixture(autouse=True)
+def _mock_verify(monkeypatch):
+    monkeypatch.setattr(event_manager.nested_miner, "verify_nested_seed", lambda c, b: True)
+
+
+def test_finalize_cli(tmp_path, capsys, monkeypatch):
+    event = event_manager.create_event("finalize cli", microblock_size=4)
+    enc = bytes([1, 1]) + b"a"
+    event_manager.accept_mined_seed(event, 0, enc)
+    event_manager.save_event(event, str(tmp_path / "events"))
+    capsys.readouterr()
+    evt_id = event["header"]["statement_id"]
+
+    monkeypatch.chdir(tmp_path)
+    helix_cli.main(["finalize", evt_id])
+    out = capsys.readouterr().out.strip()
+    assert "statement verified" in out.lower()
+
+    chain = bc.load_chain(str(tmp_path / "blockchain.jsonl"))
+    assert chain and chain[-1]["event_ids"][0] == evt_id


### PR DESCRIPTION
## Summary
- add `helix finalize` command
- verify seeds, reassemble statement, finalize and save block
- test finalize CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6b9084a0832989c26679b29b2d08