### PR TITLE
Add orphan event cleanup

### DIFF
--- a/tests/test_statement_registry.py
+++ b/tests/test_statement_registry.py
@@ -42,3 +42,34 @@ def test_rebuild_from_events(tmp_path):
         event_manager.create_event("Finalized", registry=new_reg)
 
 
+def test_cleanup_events(tmp_path):
+    registry = StatementRegistry()
+
+    events_dir = tmp_path / "events"
+    events_dir.mkdir()
+
+    evt1 = event_manager.create_event("keep", registry=registry)
+    event_manager.save_event(evt1, str(events_dir))
+    evt2 = event_manager.create_event("remove", registry=registry)
+    event_manager.save_event(evt2, str(events_dir))
+
+    (events_dir / "bad.json").write_text("{not valid")
+
+    chain_file = tmp_path / "blockchain.jsonl"
+    bc_block = {
+        "parent_id": "0" * 64,
+        "event_ids": [evt1["header"]["statement_id"]],
+        "block_id": "1" * 64,
+    }
+    import blockchain as bc
+    bc.append_block(bc_block, path=str(chain_file))
+
+    removed = registry.cleanup_events(str(events_dir), chain_file=str(chain_file))
+
+    remaining = {p.name for p in events_dir.glob("*.json")}
+    assert f"{evt1['header']['statement_id']}.json" in remaining
+    assert f"{evt2['header']['statement_id']}.json" not in remaining
+    assert "bad.json" not in remaining
+    assert len(removed) == 2
+
+


### PR DESCRIPTION
## Summary
- add `cleanup_events` to StatementRegistry for removing orphaned or invalid events
- test cleaning orphaned events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f79eab2708329bf459555c883b942