### PR TITLE
Add originator signature support

### DIFF
--- a/tests/test_statement_submission.py
+++ b/tests/test_statement_submission.py
@@ -26,4 +26,5 @@ def test_create_event_without_signature():
     event = em.create_event("No sig", microblock_size=4)
     assert "merkle_root" in event["header"]
     assert isinstance(event.get("merkle_tree"), list)
-    assert not verify_event_signature(event)
+    assert verify_event_signature(event)
+    assert "originator_pub" in event and "originator_sig" in event


### PR DESCRIPTION
## Summary
- require Ed25519 signature for every statement
- auto-generate a key pair if no private key is supplied
- validate signature during event creation
- update statement submission test

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'HelixNode' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6850634c36f48329ae55951ca54e8fcb