### PR TITLE
Fix blockchain finalize test

### DIFF
--- a/tests/test_blockchain.py
+++ b/tests/test_blockchain.py
@@ -6,15 +6,15 @@ pytest.importorskip("nacl")
 
 def test_finalize_appends_block(tmp_path):
     import helix.event_manager as em
-    from helix import minihelix
+    from helix import minihelix, nested_miner
 
     chain_file = tmp_path / "chain.jsonl"
 
-    event = em.create_event("hi", microblock_size=2)
-    target_block = event["microblocks"][0]
-    seed = minihelix.mine_seed(target_block)
-    assert seed is not None
+    seed = b"a"
+    target_block = minihelix.G(seed, 2)
+    event = em.create_event(target_block.decode("utf-8"), microblock_size=2)
     encoded = bytes([1, len(seed)]) + seed
+    assert nested_miner.verify_nested_seed(encoded, target_block)
     em.accept_mined_seed(event, 0, encoded)
     assert event["is_closed"], "event should be closed once mined"
 


### PR DESCRIPTION
## Summary
- create deterministic target microblock in blockchain test
- verify nested seed and remove random mining

## Testing
- `pytest tests/test_blockchain.py::test_finalize_appends_block -vv`

------
https://chatgpt.com/codex/tasks/task_e_685187c7f2e083299046e2cd35c31fe5