### PR TITLE
Enhance doctor command

### DIFF
--- a/blockchain.py
+++ b/blockchain.py
@@ -3,6 +3,30 @@ import hashlib
 import os
 from pathlib import Path
 from typing import List, Dict
+from helix.config import GENESIS_HASH
+
+
+def get_chain_tip(path: str = "blockchain.jsonl") -> str:
+    """Return the ``block_id`` of the last block in ``path``."""
+    file = Path(path)
+    if not file.exists():
+        return GENESIS_HASH
+
+    last_line = None
+    with open(file, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                last_line = line
+
+    if not last_line:
+        return GENESIS_HASH
+
+    try:
+        entry = json.loads(last_line)
+    except json.JSONDecodeError:
+        return GENESIS_HASH
+
+    return entry.get("block_id", GENESIS_HASH)
 
 
 def append_block(block_header: Dict, path: str = "blockchain.jsonl") -> None:

--- a/helix/helix_cli.py
+++ b/helix/helix_cli.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import hashlib
 from pathlib import Path
 
 from . import event_manager
@@ -11,6 +12,7 @@ from .ledger import load_balances, get_total_supply, compression_stats
 from .gossip import GossipNode, LocalGossipNetwork
 from .blockchain import load_chain
 from . import helix_node
+from .config import GENESIS_HASH
 
 EVENTS_DIR = Path("events")
 BALANCES_FILE = Path("balances.json")
@@ -284,6 +286,65 @@ def cmd_token_stats(args: argparse.Namespace) -> None:
     print(f"Average Reward/Event: {avg_reward:.4f}")
 
 
+def cmd_doctor(args: argparse.Namespace) -> None:
+    """Diagnose local node files and print status information."""
+    base = Path(args.data_dir)
+
+    # Genesis block check
+    genesis = base / "genesis.json"
+    if not genesis.exists():
+        print("genesis.json not found")
+    else:
+        digest = hashlib.sha256(genesis.read_bytes()).hexdigest()
+        if digest != GENESIS_HASH:
+            print("hash mismatch")
+
+    # Microblock counts
+    events_dir = base / "events"
+    mined = 0
+    unmined = 0
+    if events_dir.exists():
+        for path in events_dir.glob("*.json"):
+            ev = event_manager.load_event(str(path))
+            statuses = ev.get("mined_status", [False] * len(ev.get("microblocks", [])))
+            mined_blocks = sum(1 for m in statuses if m)
+            total_blocks = ev.get("header", {}).get(
+                "block_count", len(ev.get("microblocks", []))
+            )
+            mined += mined_blocks
+            unmined += total_blocks - mined_blocks
+    print(f"Mined microblocks: {mined}")
+    print(f"Unmined microblocks: {unmined}")
+
+    # Wallet and balance
+    wallet = base / "wallet.txt"
+    if wallet.exists():
+        try:
+            pub, _ = signature_utils.load_keys(str(wallet))
+            balances_file = base / "balances.json"
+            balances = load_balances(str(balances_file))
+            balance = balances.get(pub, 0)
+            print(f"Wallet balance: {balance}")
+        except Exception:
+            print("wallet inaccessible")
+    else:
+        print("no wallet file")
+
+    # Chain info
+    chain_path = base / "blockchain.jsonl"
+    if not chain_path.exists():
+        alt = base / "chain.json"
+        if alt.exists():
+            chain_path = alt
+    blocks = load_chain(str(chain_path))
+    if blocks:
+        height = len(blocks) - 1
+        ts = blocks[-1].get("timestamp")
+        print(f"Latest block: {height} {ts}")
+    else:
+        print("No chain data found")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="helix",
@@ -291,6 +352,19 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     sub = parser.add_subparsers(dest="command", required=True)
+
+    p_doc = sub.add_parser(
+        "doctor",
+        help="Check local node files",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p_doc.add_argument(
+        "--data-dir",
+        default="data",
+        metavar="DIR",
+        help="Directory containing node data",
+    )
+    p_doc.set_defaults(func=cmd_doctor)
 
     p_submit = sub.add_parser(
         "submit-statement",
@@ -491,6 +565,7 @@ __all__ = [
     "build_parser",
     "cmd_init",
     "initialize_genesis_block",
+    "cmd_doctor",
     "cmd_token_stats",
     "cmd_submit_and_mine",
 ]

--- a/tests/test_helix_cli_doctor.py
+++ b/tests/test_helix_cli_doctor.py
@@ -1,0 +1,54 @@
+import json
+from pathlib import Path
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import helix_cli, event_manager, signature_utils
+
+
+@pytest.fixture(autouse=True)
+def _mock_verify(monkeypatch):
+    monkeypatch.setattr(event_manager.nested_miner, "verify_nested_seed", lambda c, b: True)
+
+
+def test_helix_cli_doctor_missing_genesis(tmp_path, capsys):
+    helix_cli.main(["doctor", "--data-dir", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert "genesis.json not found" in out
+
+
+def test_helix_cli_doctor_invalid_hash(tmp_path, capsys):
+    (tmp_path / "genesis.json").write_text("{}")
+    helix_cli.main(["doctor", "--data-dir", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert "hash mismatch" in out
+
+
+def test_helix_cli_doctor_summary(tmp_path, capsys):
+    genesis_src = Path("genesis.json")
+    (tmp_path / "genesis.json").write_bytes(genesis_src.read_bytes())
+
+    pub, priv = signature_utils.generate_keypair()
+    wallet = tmp_path / "wallet.txt"
+    signature_utils.save_keys(str(wallet), pub, priv)
+    with open(tmp_path / "balances.json", "w", encoding="utf-8") as f:
+        json.dump({pub: 50}, f)
+
+    event1 = event_manager.create_event("ab", microblock_size=1)
+    event_manager.save_event(event1, str(tmp_path / "events"))
+
+    event2 = event_manager.create_event("c", microblock_size=2)
+    event_manager.accept_mined_seed(event2, 0, [b"a"])
+    event_manager.save_event(event2, str(tmp_path / "events"))
+
+    chain_data = [{"block_id": "b1", "parent_id": "genesis", "timestamp": 123}]
+    (tmp_path / "chain.json").write_text(json.dumps(chain_data))
+
+    helix_cli.main(["doctor", "--data-dir", str(tmp_path)])
+    out = capsys.readouterr().out
+
+    assert "Mined microblocks: 1" in out
+    assert "Unmined microblocks: 2" in out
+    assert "Wallet balance: 50" in out
+    assert "Latest block: 0 123" in out


### PR DESCRIPTION
## Summary
- implement new `doctor` command in `helix_cli`
- add CLI option for doctor command
- expose `get_chain_tip` in root blockchain module
- test doctor command behaviour

## Testing
- `pytest tests/test_helix_cli_doctor.py -q`
- `pytest -q` *(fails: invalid seed chain, missing genesis file, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685187d7c46c8329916f4c58ea42ce58