### PR TITLE
Add diagnostics for node health

### DIFF
--- a/blockchain.py
+++ b/blockchain.py
@@ -4,6 +4,31 @@ import os
 from pathlib import Path
 from typing import List, Dict
 
+from helix.config import GENESIS_HASH
+
+
+def get_chain_tip(path: str = "blockchain.jsonl") -> str:
+    """Return ``block_id`` of the last block in ``path``."""
+    file = Path(path)
+    if not file.exists():
+        return GENESIS_HASH
+
+    last: str | None = None
+    with open(file, "r", encoding="utf-8") as fh:
+        for line in fh:
+            if line.strip():
+                last = line
+
+    if not last:
+        return GENESIS_HASH
+
+    try:
+        entry = json.loads(last)
+    except json.JSONDecodeError:
+        return GENESIS_HASH
+
+    return entry.get("block_id", GENESIS_HASH)
+
 
 def append_block(block_header: Dict, path: str = "blockchain.jsonl") -> None:
     """Append ``block_header`` to the chain at ``path`` as newline-delimited JSON."""


### PR DESCRIPTION
## Summary
- enhance `doctor` command with peer checks and block validation
- report missed microblocks and invalid seeds
- expose `get_chain_tip` helper in blockchain module

## Testing
- `python run_tests.py` *(fails: 19 failed, 62 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68518897096c83299056819364518a30