### PR TITLE
Add verify-statement CLI command

### DIFF
--- a/helix/cli.py
+++ b/helix/cli.py
@@ -104,6 +104,41 @@ def cmd_reassemble(args: argparse.Namespace) -> None:
     print(statement)
 
 
+def cmd_verify_statement(args: argparse.Namespace) -> None:
+    """Verify and output a finalized statement."""
+    events_dir = Path(args.data_dir) / "events"
+    path = events_dir / f"{args.statement_hash}.json"
+    if not path.exists():
+        raise SystemExit("Event not found")
+
+    event = event_manager.load_event(str(path))
+
+    blocks = event.get("microblocks", [])
+    seeds = event.get("seeds", [])
+
+    if len(blocks) != len(seeds) or any(s is None for s in seeds):
+        raise SystemExit("missing mined seeds")
+
+    for idx, block in enumerate(blocks):
+        seed_chain = seeds[idx]
+        if not event_manager.verify_seed_chain(seed_chain, block):
+            raise SystemExit(f"invalid seed for block {idx}")
+
+    root, _tree = merkle_utils.build_merkle_tree(blocks)
+    hdr_root = event.get("header", {}).get("merkle_root")
+    if isinstance(hdr_root, str):
+        hdr_root = bytes.fromhex(hdr_root)
+    if hdr_root != root:
+        raise SystemExit("Merkle root mismatch")
+
+    statement = event_manager.reassemble_microblocks(blocks)
+    digest = event_manager.sha256(statement.encode("utf-8"))
+    if digest != args.statement_hash:
+        raise SystemExit("SHA-256 mismatch")
+
+    print(statement)
+
+
 def cmd_token_stats(args: argparse.Namespace) -> None:
     events_dir = Path(args.data_dir) / "events"
     total = get_total_supply(str(events_dir))
@@ -231,6 +266,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_view.add_argument("event_id", help="Event identifier")
     p_view.set_defaults(func=cmd_view_event)
 
+    p_verify = sub.add_parser(
+        "verify-statement", help="Verify statement integrity"
+    )
+    p_verify.add_argument("statement_hash", help="Statement hash")
+    p_verify.set_defaults(func=cmd_verify_statement)
+
     return parser
 
 
@@ -250,4 +291,5 @@ __all__ = [
     "cmd_view_chain",
     "cmd_remine_microblock",
     "cmd_view_event",
+    "cmd_verify_statement",
 ]

--- a/tests/test_cli_verify_statement.py
+++ b/tests/test_cli_verify_statement.py
@@ -1,0 +1,25 @@
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import cli, event_manager as em
+
+
+@pytest.fixture(autouse=True)
+def _mock_verify(monkeypatch):
+    monkeypatch.setattr(em, "verify_seed_chain", lambda c, b: True)
+    monkeypatch.setattr(em.nested_miner, "verify_nested_seed", lambda c, b: True)
+
+
+def test_cli_verify_statement(tmp_path, capsys):
+    statement = "verify me"
+    event = em.create_event(statement, microblock_size=2)
+    enc = bytes([1, 1]) + b"a"
+    for idx, _ in enumerate(event["microblocks"]):
+        em.accept_mined_seed(event, idx, enc)  # dummy encoded seed
+    em.save_event(event, str(tmp_path / "events"))
+    evt_id = event["header"]["statement_id"]
+
+    cli.main(["--data-dir", str(tmp_path), "verify-statement", evt_id])
+    out = capsys.readouterr().out.strip()
+    assert out.endswith(statement)


### PR DESCRIPTION
## Summary
- add `verify-statement` command to `helix-cli`
- verify merkle root and seed chains for a statement
- add tests for the new command

## Testing
- `pytest tests/test_cli_verify_statement.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685188b3dd008329a741c1f1a89fc5c8