### PR TITLE
Improve gossip deduplication

### DIFF
--- a/helix/network/gossip.py
+++ b/helix/network/gossip.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
+import time
 from typing import Dict, Any
 
 from .peer import Peer
@@ -11,15 +14,44 @@ from .transport import GossipTransport
 class SocketGossipNetwork:
     """Peer-to-peer gossip network using a :class:`GossipTransport`."""
 
-    def __init__(self, transport: GossipTransport) -> None:
+    def __init__(self, transport: GossipTransport, *, seen_ttl: float = 300.0) -> None:
         self.transport = transport
         self._peers: dict[str, Peer] = {}
+        self._seen: dict[str, float] = {}
+        self._seen_ttl = seen_ttl
+
+    def _hash_message(self, message: Dict[str, Any]) -> str:
+        data = json.dumps(message, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        return hashlib.sha256(data).hexdigest()
+
+    def _purge_seen(self) -> None:
+        if not self._seen:
+            return
+        now = time.monotonic()
+        expired = [h for h, t in self._seen.items() if now - t > self._seen_ttl]
+        for h in expired:
+            self._seen.pop(h, None)
+
+    def _is_new(self, message: Dict[str, Any]) -> bool:
+        h = self._hash_message(message)
+        self._purge_seen()
+        return h not in self._seen
+
+    def _mark_seen(self, message: Dict[str, Any]) -> None:
+        h = self._hash_message(message)
+        self._purge_seen()
+        self._seen[h] = time.monotonic()
 
     def register(self, node_id: str, peer: Peer) -> None:
         self._peers[node_id] = peer
         self.transport.add_peer(peer)
 
     def send(self, sender_id: str, message: Dict[str, Any]) -> None:
+        if not self._is_new(message):
+            return
+        self._mark_seen(message)
         for node_id, peer in self._peers.items():
             if node_id == sender_id:
                 continue

--- a/tests/test_gossip.py
+++ b/tests/test_gossip.py
@@ -67,3 +67,19 @@ def test_receive_deduplicates():
     with pytest.raises(queue.Empty):
         node_b.receive(timeout=0.1)
     assert received["type"] == "STATEMENT"
+
+
+def test_network_filters_duplicate():
+    network = LocalGossipNetwork()
+    node_a = GossipNode("A", network)
+    node_b = GossipNode("B", network)
+
+    msg = {"type": "STATEMENT", "event_id": "z", "index": 3}
+    network.send("A", msg)
+    network.send("A", msg)
+
+    assert node_b._queue.qsize() == 1
+    received = node_b.receive(timeout=1)
+    with pytest.raises(queue.Empty):
+        node_b.receive(timeout=0.1)
+    assert received["type"] == "STATEMENT"


### PR DESCRIPTION
## Summary
- prevent rebroadcasting duplicate gossip messages
- track message hashes within LocalGossipNetwork and SocketGossipNetwork
- test deduplication of duplicate network messages

## Testing
- `pytest tests/test_gossip.py::test_network_filters_duplicate -q`
- `pytest -q` *(fails: FileNotFoundError, TypeError, AssertionError, ModuleNotFoundError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_685188bc07bc8329912772c9bf779635