### PR TITLE
Add token stats summary

### DIFF
--- a/helix/cli.py
+++ b/helix/cli.py
@@ -105,9 +105,26 @@ def cmd_reassemble(args: argparse.Namespace) -> None:
 
 
 def cmd_token_stats(args: argparse.Namespace) -> None:
+    """Display aggregated token metrics."""
     events_dir = Path(args.data_dir) / "events"
-    total = get_total_supply(str(events_dir))
-    print(f"Total HLX Issued: {total:.4f}")
+
+    total_minted = 0.0
+    total_burned = 0.0
+
+    if events_dir.exists():
+        for path in events_dir.glob("*.json"):
+            event = event_manager.load_event(str(path))
+            rewards = event.get("rewards", [])
+            refunds = event.get("refunds", [])
+            total_minted += sum(rewards) - sum(refunds)
+            total_burned += float(event.get("header", {}).get("gas_fee", 0))
+
+    supply = total_minted - total_burned
+
+    print(f"Total HLX Supply: {supply:.4f}")
+    print(f"Burned from Gas: {total_burned:.4f}")
+    print(f"HLX Minted via Compression: {total_minted:.4f}")
+    print("Token Velocity: N/A")
 
 
 def cmd_view_chain(args: argparse.Namespace) -> None:

--- a/helix/helix_cli.py
+++ b/helix/helix_cli.py
@@ -261,27 +261,26 @@ def cmd_finalize(args: argparse.Namespace) -> None:
 
 
 def cmd_token_stats(args: argparse.Namespace) -> None:
-    """Print overall token distribution statistics."""
+    """Print aggregated token statistics."""
     events_dir = Path(args.data_dir) / "events"
-    total_hlx = get_total_supply(str(events_dir))
-    mined_events = 0
-    total_reward = 0.0
+
+    minted = 0.0
+    burned = 0.0
 
     if events_dir.exists():
         for path in events_dir.glob("*.json"):
             event = event_manager.load_event(str(path))
             rewards = event.get("rewards", [])
             refunds = event.get("refunds", [])
-            reward = sum(rewards) - sum(refunds)
-            if event.get("is_closed"):
-                mined_events += 1
-                total_reward += reward
+            minted += sum(rewards) - sum(refunds)
+            burned += float(event.get("header", {}).get("gas_fee", 0))
 
-    avg_reward = total_reward / mined_events if mined_events else 0.0
+    supply = minted - burned
 
-    print(f"Total HLX Supply: {total_hlx:.4f}")
-    print(f"Total Mined Events: {mined_events}")
-    print(f"Average Reward/Event: {avg_reward:.4f}")
+    print(f"Total HLX Supply: {supply:.4f}")
+    print(f"Burned from Gas: {burned:.4f}")
+    print(f"HLX Minted via Compression: {minted:.4f}")
+    print("Token Velocity: N/A")
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tests/test_cli_token_stats.py
+++ b/tests/test_cli_token_stats.py
@@ -18,6 +18,9 @@ def test_cli_token_stats(tmp_path, capsys):
     capsys.readouterr()  # clear mark_mined output
 
     cli.main(["--data-dir", str(tmp_path), "token-stats"])
-    out = capsys.readouterr().out.strip()
+    out_lines = capsys.readouterr().out.strip().splitlines()
     expected = sum(event["rewards"]) - sum(event["refunds"])
-    assert f"Total HLX Issued: {expected:.4f}" in out
+    assert f"Total HLX Supply: {expected:.4f}" in out_lines[0]
+    assert "Burned from Gas: 0.0000" in out_lines[1]
+    assert f"HLX Minted via Compression: {expected:.4f}" in out_lines[2]
+    assert "Token Velocity: N/A" in out_lines[3]

--- a/tests/test_helix_cli_token_stats.py
+++ b/tests/test_helix_cli_token_stats.py
@@ -21,5 +21,6 @@ def test_helix_cli_token_stats(tmp_path, capsys):
     out_lines = capsys.readouterr().out.strip().splitlines()
     expected = sum(event["rewards"]) - sum(event["refunds"])
     assert f"Total HLX Supply: {expected:.4f}" in out_lines[0]
-    assert "Total Mined Events: 1" in out_lines[1]
-    assert f"Average Reward/Event: {expected:.4f}" in out_lines[2]
+    assert "Burned from Gas: 0.0000" in out_lines[1]
+    assert f"HLX Minted via Compression: {expected:.4f}" in out_lines[2]
+    assert "Token Velocity: N/A" in out_lines[3]


### PR DESCRIPTION
## Summary
- extend CLI `token-stats` subcommand to show new metrics
- update helix CLI accordingly
- adjust tests for new output

## Testing
- `pytest tests/test_cli_token_stats.py tests/test_helix_cli_token_stats.py -q`
- `pytest -q` *(fails: ModuleNotFoundError & other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685188c7ad0c8329a6af73c1a7821cc8