### PR TITLE
Add genesis initialization utility

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -200,6 +200,15 @@ def mark_mined(event: Dict[str, Any], index: int) -> None:
         event["is_closed"] = True
         print(f"Event {event['header']['statement_id']} is now closed.")
 
+
+def mint_uncompressed_seeds(event: Dict[str, Any]) -> None:
+    """Mark all microblocks as mined using the blocks themselves as seeds."""
+    microblocks = event.get("microblocks", [])
+    for idx, block in enumerate(microblocks):
+        event["seeds"][idx] = block
+        event["seed_depths"][idx] = 1
+        mark_mined(event, idx)
+
 def finalize_event(
     event: Dict[str, Any], *, node_id: Optional[str] = None, chain_file: str = "blockchain.jsonl",
     balances_file: Optional[str] = None, _bc: Any | None = None

--- a/helix/signature_utils.py
+++ b/helix/signature_utils.py
@@ -30,6 +30,11 @@ def sign_data(data: bytes, private_key: str) -> str:
     return base64.b64encode(signed.signature).decode("ascii")
 
 
+def sign_statement(statement: str, private_key: str) -> str:
+    """Return a base64 signature for ``statement`` using ``private_key``."""
+    return sign_data(statement.encode("utf-8"), private_key)
+
+
 def verify_signature(data: bytes, signature: str, public_key: str) -> bool:
     """Verify that ``signature`` matches ``data`` for ``public_key``."""
     sig_bytes = base64.b64decode(signature)
@@ -68,6 +73,7 @@ def load_or_create_keys(filename: str) -> Tuple[str, str]:
 
 __all__ = [
     "generate_keypair",
+    "sign_statement",
     "sign_data",
     "verify_signature",
     "save_keys",

--- a/scripts/init_genesis.py
+++ b/scripts/init_genesis.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Initialize the Helix genesis block with uncompressed seeds."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from helix import event_manager, signature_utils
+
+
+def main() -> None:
+    # 1. Load or create Ed25519 wallet keys
+    pub, priv = signature_utils.load_or_create_keys("wallet.json")
+
+    # 2. The genesis statement
+    statement = "Helix is to data what logic is to language."
+
+    # 3. Set microblock size
+    microblock_size = 3
+
+    # 4. Sign the statement
+    signature = signature_utils.sign_statement(statement, priv)
+
+    # 5. Create the event (signature stored separately)
+    event = event_manager.create_event(
+        statement=statement,
+        microblock_size=microblock_size,
+        private_key=priv,
+    )
+    # Override with explicit signature and pubkey
+    event["originator_pub"] = pub
+    event["originator_sig"] = signature
+
+    # 6. Prepare events directory
+    events_dir = Path("data/events")
+    events_dir.mkdir(parents=True, exist_ok=True)
+
+    # 7. Treat microblocks as mined seeds
+    event_manager.mint_uncompressed_seeds(event)
+
+    # Save the event to disk
+    event_manager.save_event(event, str(events_dir))
+
+    # 8. Finalize the event
+    payouts = event_manager.finalize_event(
+        event=event,
+        node_id="GENESIS_NODE",
+        chain_file="chain.json",
+        balances_file="balances.json",
+    )
+
+    # Load block hash from chain file
+    chain_file = Path("chain.json")
+    block_hash = None
+    if chain_file.exists():
+        try:
+            with open(chain_file, "r", encoding="utf-8") as fh:
+                lines = fh.readlines()
+                if lines:
+                    block = json.loads(lines[-1])
+                    block_hash = block.get("block_id")
+        except Exception:
+            pass
+
+    # 9. Print results
+    print("Finalized block hash:", block_hash)
+    print("Statement:", statement)
+    print("Payout distribution:")
+    print(json.dumps(payouts, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `sign_statement` helper
- add `mint_uncompressed_seeds` to event manager
- create `scripts/init_genesis.py` to generate and finalize a genesis event

## Testing
- `pytest -q` *(fails: 32 failed, 58 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685191132ab48329b333cac47dad79c9