### PR TITLE
Implement mint_uncompressed_seeds helper

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -414,6 +414,18 @@ def accept_mined_seed(
 
     return refund
 
+
+def mint_uncompressed_seeds(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Mark each microblock as mined using its raw bytes as the seed."""
+
+    blocks = event.get("microblocks", [])
+    event.setdefault("mined", [False] * len(blocks))
+    for i, block in enumerate(blocks):
+        accept_mined_seed(event, i, [block])
+        event["mined"][i] = True
+
+    return event
+
 def save_event(event: Dict[str, Any], directory: str) -> str:
     path = Path(directory)
     path.mkdir(parents=True, exist_ok=True)

--- a/tests/test_event_manager.py
+++ b/tests/test_event_manager.py
@@ -47,3 +47,13 @@ def test_reject_oversize_seed():
     event = em.create_event("ab", microblock_size=2)
     with pytest.raises(ValueError):
         em.accept_mined_seed(event, 0, bytes([1, 7]) + b"toolong")
+
+
+def test_mint_uncompressed_seeds():
+    event = em.create_event("abcd", microblock_size=2)
+    em.mint_uncompressed_seeds(event)
+    assert all(event["mined"])
+    assert all(event["mined_status"])
+    for idx, block in enumerate(event["microblocks"]):
+        assert event["seeds"][idx] == [block]
+    assert event["is_closed"]


### PR DESCRIPTION
## Summary
- implement `mint_uncompressed_seeds` in `event_manager`
- test uncompressed minting in the event manager tests

## Testing
- `pytest tests/test_event_manager.py::test_mint_uncompressed_seeds -q`
- `pytest -q` *(fails: multiple tests fail due to missing setup/environment)*

------
https://chatgpt.com/codex/tasks/task_e_6851911d3fd8832990989a94a7e7d77a