### PR TITLE
Add view-chain command

### DIFF
--- a/tests/test_helix_cli_view_chain.py
+++ b/tests/test_helix_cli_view_chain.py
@@ -19,9 +19,17 @@ def test_view_chain(tmp_path, capsys):
     capsys.readouterr()  # clear output from mark_mined
 
     evt_id = event["header"]["statement_id"]
-    chain_data = [{"block_id": "b1", "parent_id": "genesis", "event_ids": [evt_id]}]
+    chain_data = [
+        {
+            "block_id": "b1",
+            "parent_id": "genesis",
+            "event_ids": [evt_id],
+            "timestamp": 123,
+        }
+    ]
     (tmp_path / "chain.json").write_text(json.dumps(chain_data))
 
-    helix_cli.main(["view-chain", "--data-dir", str(tmp_path), "--summary"])
-    out = capsys.readouterr().out.strip()
-    assert f"0 {evt_id} b1 1" in out
+    helix_cli.main(["view-chain", "--data-dir", str(tmp_path)])
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out[0] == f"0 {evt_id} 123 1"
+    assert out[-1] == "Total blocks: 1"


### PR DESCRIPTION
## Summary
- implement `cmd_view_chain` command to inspect chain
- expose `view-chain` via parser and `__all__`
- test new command

## Testing
- `pytest -q tests/test_helix_cli_view_chain.py -vv`
- `pytest -q` *(fails: invalid choice 'finalize' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6851914669e08329aea4b7942dd72961