### PR TITLE
Track attempts during exhaustive mining

### DIFF
--- a/helix/exhaustive_miner.py
+++ b/helix/exhaustive_miner.py
@@ -30,13 +30,17 @@ class ExhaustiveMiner:
         self.block_size = len(target_block)
         self.max_depth = max_depth
         self.initial_seeds = list(_generate_initial_seeds())
+        self.attempts = 0
 
     def _dfs(self, seed: bytes, depth: int, chain: List[bytes]) -> Optional[List[bytes]]:
         """Depth-first search returning the seed chain or ``None``."""
+        self.attempts += 1
         output = G(seed, self.block_size)
         chain.append(seed)
         if output == self.target:
-            return list(chain)
+            result = list(chain)
+            print(f"Attempts for microblock: {self.attempts}")
+            return result
         if depth >= self.max_depth:
             chain.pop()
             return None
@@ -56,11 +60,13 @@ class ExhaustiveMiner:
 
     def mine(self, start_index: int = 0) -> Optional[List[bytes]]:
         """Search for a compression seed chain starting from ``start_index``."""
+        self.attempts = 0
         for idx in range(start_index, len(self.initial_seeds)):
             seed = self.initial_seeds[idx]
             result = self._dfs(seed, 1, [])
             if result is not None:
                 return result
+        print(f"Attempts for microblock: {self.attempts}")
         return None
 
 

--- a/tests/test_exhaustive_miner.py
+++ b/tests/test_exhaustive_miner.py
@@ -1,19 +1,39 @@
 from helix import exhaustive_miner, minihelix
 
 
-def test_exhaustive_mine_single_seed():
+def test_exhaustive_mine_single_seed(capsys):
     N = 4
     seed = bytes.fromhex("9c")
     block = minihelix.G(seed, N)
-    result = exhaustive_miner.exhaustive_mine(block, max_depth=1)
+    miner = exhaustive_miner.ExhaustiveMiner(block, max_depth=1)
+    result = miner.mine()
+    out = capsys.readouterr().out
     assert result == [seed]
+    assert "Attempts for microblock" in out
+    assert miner.attempts > 0
 
 
-def test_exhaustive_mine_nested_seed():
+def test_exhaustive_mine_nested_seed(capsys):
     N = 4
     base_seed = bytes.fromhex("cf")
     second_seed = bytes.fromhex("0033")
     target = minihelix.G(second_seed, N)
     start_index = int.from_bytes(base_seed, "big")
-    result = exhaustive_miner.exhaustive_mine(target, max_depth=2, start_index=start_index)
+    miner = exhaustive_miner.ExhaustiveMiner(target, max_depth=2)
+    result = miner.mine(start_index=start_index)
+    out = capsys.readouterr().out
     assert result == [base_seed, second_seed]
+    assert "Attempts for microblock" in out
+    assert miner.attempts > 0
+
+
+def test_exhaustive_mine_failure(capsys):
+    N = 2
+    seed = b"xyz"
+    target = minihelix.G(seed, N)
+    miner = exhaustive_miner.ExhaustiveMiner(target, max_depth=1)
+    result = miner.mine()
+    out = capsys.readouterr().out
+    assert result is None
+    assert "Attempts for microblock" in out
+    assert miner.attempts > 0


### PR DESCRIPTION
## Summary
- keep count of exhaustive mining attempts
- expose `attempts` attribute and print attempts per microblock
- test attempt tracking

## Testing
- `pytest tests/test_exhaustive_miner.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b479284c832997f7e252313073ab