### PR TITLE
Align nested seed verification with depth rules

### DIFF
--- a/helix/nested_miner.py
+++ b/helix/nested_miner.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from . import minihelix
 from .minihelix import G, mine_seed
 
+# Maximum supported depth when validating nested seed chains.  This
+# mirrors the limit enforced by :mod:`helix.exhaustive_miner` and
+# prevents extremely deep (and expensive) chains from being accepted.
+MAX_DEPTH = 500
+
 
 class NestedSeed(bytes):
     """Representation of a mined nested seed chain."""
@@ -127,8 +132,15 @@ def verify_nested_seed(
     target_block: bytes,
     *,
     max_steps: int = 1000,
+    max_depth: int = MAX_DEPTH,
 ) -> bool:
-    """Return True if ``seed_chain`` regenerates ``target_block``."""
+    """Return ``True`` if ``seed_chain`` regenerates ``target_block``.
+
+    The chain may be provided either as a list of seeds/microblocks or as
+    the encoded bytes returned by :func:`find_nested_seed`.  Validation is
+    bounded by ``max_depth`` and ``max_steps`` to mirror the main mining
+    logic.
+    """
     N = len(target_block)
 
     if isinstance(seed_chain, (bytes, bytearray)):
@@ -139,10 +151,12 @@ def verify_nested_seed(
         expected_len = 2 + seed_len + (depth - 1) * N
         if len(seed_chain) != expected_len:
             return False
+        if depth == 0 or depth > max_depth or depth - 1 > max_steps:
+            return False
 
         offset = 2
         seed = seed_chain[offset : offset + seed_len]
-        if not (0 < len(seed) <= N):
+        if not _seed_is_valid(seed, N):
             return False
         offset += seed_len
         current = seed
@@ -150,18 +164,26 @@ def verify_nested_seed(
             if step_num > max_steps:
                 return False
             current = G(current, N)
-            if current != seed_chain[offset : offset + N]:
+            next_block = seed_chain[offset : offset + N]
+            if len(next_block) != N or current != next_block:
                 return False
             offset += N
         current = G(current, N)
         return current == target_block
 
     # List version
-    if not seed_chain or not (0 < len(seed_chain[0]) <= N):
+    if not seed_chain:
         return False
-    if len(seed_chain) - 1 >= max_steps:
+    if len(seed_chain) > max_depth or len(seed_chain) - 1 > max_steps:
         return False
-    current = seed_chain[0]
+    seed = seed_chain[0]
+    if not _seed_is_valid(seed, N):
+        return False
+    for block in seed_chain[1:]:
+        if len(block) != N:
+            return False
+
+    current = seed
     for step_num, step in enumerate(seed_chain[1:], start=1):
         if step_num > max_steps:
             return False

--- a/tests/test_nested_miner.py
+++ b/tests/test_nested_miner.py
@@ -31,10 +31,31 @@ def test_verify_nested_seed_max_steps_limit():
     seed = b"s"
     chain = [seed]
     current = seed
-    for _ in range(1000):
+    # create a short chain to exercise the max_steps check without
+    # exceeding the global MAX_DEPTH limit
+    for _ in range(6):
         current = minihelix.G(current, N)
         chain.append(current)
     target = minihelix.G(current, N)
 
-    assert not nested_miner.verify_nested_seed(chain, target)
-    assert nested_miner.verify_nested_seed(chain, target, max_steps=1001)
+    assert not nested_miner.verify_nested_seed(chain, target, max_steps=5)
+    assert nested_miner.verify_nested_seed(chain, target, max_steps=6)
+
+
+def test_verify_nested_seed_max_depth_limit():
+    N = 1
+    seed = b"s"
+    chain = [seed]
+    current = seed
+    for _ in range(nested_miner.MAX_DEPTH):
+        current = minihelix.G(current, N)
+        chain.append(current)
+    target = minihelix.G(current, N)
+
+    assert not nested_miner.verify_nested_seed(chain, target, max_steps=len(chain) - 1)
+    assert nested_miner.verify_nested_seed(
+        chain,
+        target,
+        max_steps=len(chain) - 1,
+        max_depth=nested_miner.MAX_DEPTH + 1,
+    )


### PR DESCRIPTION
## Summary
- enforce a max depth constant in `nested_miner`
- validate depth and block sizes when verifying nested seeds
- extend tests for depth/step limits

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_nested_miner.py::test_verify_nested_seed_max_steps_limit -q`
- `pytest tests/test_nested_miner.py -q`
- `pytest -q` *(fails: genesis file hash mismatch and missing optional deps)*

------
https://chatgpt.com/codex/tasks/task_e_6851b537ae3c8329b5da12b83b8ec54c