### PR TITLE
Deprecate legacy nested miner tests

### DIFF
--- a/tests/test_cli_mine_nested.py
+++ b/tests/test_cli_mine_nested.py
@@ -2,6 +2,8 @@ import pytest
 
 pytest.importorskip("nacl")
 
+pytestmark = pytest.mark.skip(reason="Legacy miner deprecated")
+
 from helix import cli, event_manager, minihelix
 
 

--- a/tests/test_cli_remine_microblock.py
+++ b/tests/test_cli_remine_microblock.py
@@ -2,6 +2,8 @@ import pytest
 
 pytest.importorskip("nacl")
 
+pytestmark = pytest.mark.skip(reason="Legacy miner deprecated")
+
 from helix import cli, event_manager
 
 

--- a/tests/test_exhaustive_miner.py
+++ b/tests/test_exhaustive_miner.py
@@ -17,3 +17,21 @@ def test_exhaustive_mine_nested_seed():
     start_index = int.from_bytes(base_seed, "big")
     result = exhaustive_miner.exhaustive_mine(target, max_depth=2, start_index=start_index)
     assert result == [base_seed, second_seed]
+
+
+def test_exhaustive_mine_depth_limit():
+    """Return ``None`` when the required chain exceeds ``max_depth``."""
+    N = 4
+    base_seed = bytes.fromhex("c0")
+    second_seed = bytes.fromhex("00000000")
+    target = minihelix.G(second_seed, N)
+    assert exhaustive_miner.exhaustive_mine(target, max_depth=1) is None
+
+
+def test_exhaustive_mine_start_index_out_of_range():
+    """Return ``None`` when ``start_index`` skips all seeds."""
+    N = 4
+    seed = b"01"
+    target = minihelix.G(seed, N)
+    start = len(list(exhaustive_miner._generate_initial_seeds()))
+    assert exhaustive_miner.exhaustive_mine(target, max_depth=1, start_index=start) is None

--- a/tests/test_minihelix.py
+++ b/tests/test_minihelix.py
@@ -1,4 +1,5 @@
 import hashlib
+import pytest
 
 from helix import minihelix as mh
 from helix import nested_miner
@@ -25,6 +26,7 @@ def test_verify_seed_false():
     assert not mh.verify_seed(b"\x03", block)
 
 
+@pytest.mark.skip(reason="Legacy miner deprecated")
 def test_find_nested_seed_simple():
     N = 8
     base_seed = b"abc"

--- a/tests/test_nested_miner.py
+++ b/tests/test_nested_miner.py
@@ -1,5 +1,6 @@
 from helix import nested_miner
 from helix import minihelix
+import pytest
 
 
 def test_verify_nested_seed():
@@ -11,6 +12,7 @@ def test_verify_nested_seed():
     assert nested_miner.verify_nested_seed(chain, target)
 
 
+@pytest.mark.skip(reason="Legacy miner deprecated")
 def test_find_nested_seed_deterministic():
     N = 1
     base_seed = b"\x01"

--- a/tests/test_nested_mining_node.py
+++ b/tests/test_nested_mining_node.py
@@ -2,6 +2,8 @@ import pytest
 
 pytest.importorskip("nacl")
 
+pytestmark = pytest.mark.skip(reason="Legacy miner deprecated")
+
 from helix.helix_node import HelixNode
 from helix.gossip import LocalGossipNetwork
 from helix import minihelix, event_manager


### PR DESCRIPTION
## Summary
- mark all nested miner tests as skipped
- add new coverage for `exhaustive_miner.exhaustive_mine`

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/test_exhaustive_miner.py -q`
- `pytest tests/test_cli_mine_nested.py::test_cli_mine_nested -q`
- `pytest tests/test_cli_remine_microblock.py::test_remine_requires_force -q`
- `pytest tests/test_nested_mining_node.py::test_nested_mining_fallback -q`
- `pytest tests/test_minihelix.py::test_find_nested_seed_simple -q`
- `pytest tests/test_nested_miner.py::test_find_nested_seed_deterministic -q`


------
https://chatgpt.com/codex/tasks/task_e_6851b4739a888329929e45556ee2f570