### PR TITLE
Switch to exhaustive mining API

### DIFF
--- a/helix/cli.py
+++ b/helix/cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from . import (
     event_manager,
     nested_miner,
+    exhaustive_miner,
     betting_interface,
     signature_utils,
     merkle_utils,
@@ -111,11 +112,10 @@ def cmd_mine(args: argparse.Namespace) -> None:
     for idx, block in enumerate(event.get("microblocks", [])):
         if event.get("seeds", [None])[idx] is not None:
             continue
-        result = nested_miner.find_nested_seed(block)
-        if result is None:
+        chain = exhaustive_miner.exhaustive_mine(block)
+        if chain is None:
             print(f"No seed found for block {idx}")
             continue
-        chain, _depth = result
         if not nested_miner.verify_nested_seed(chain, block):
             print(f"Verification failed for block {idx}")
             continue
@@ -130,11 +130,10 @@ def cmd_remine_microblock(args: argparse.Namespace) -> None:
         raise SystemExit("Event not found")
     event = event_manager.load_event(str(path))
     block = event["microblocks"][args.index]
-    result = nested_miner.find_nested_seed(block)
-    if result is None:
+    chain = exhaustive_miner.exhaustive_mine(block)
+    if chain is None:
         print("No seed found")
         return
-    chain, _depth = result
     if not nested_miner.verify_nested_seed(chain, block):
         print("Verification failed")
         return

--- a/scripts/init_genesis.py
+++ b/scripts/init_genesis.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from helix import event_manager, signature_utils, nested_miner
+from helix import event_manager, signature_utils, exhaustive_miner
 
 
 def main() -> None:
@@ -32,18 +32,16 @@ def main() -> None:
 
     # 6. Mine each microblock
     for idx, block in enumerate(event["microblocks"]):
-        result = nested_miner.find_nested_seed(block, max_depth=500)
-        if result is None:
+        chain = exhaustive_miner.exhaustive_mine(block, max_depth=500)
+        if chain is None:
             print(f"Microblock {idx}: no seed found")
             continue
 
-        event["seeds"][idx] = result.encoded
-        event["seed_depths"][idx] = result.depth
-        event_manager.mark_mined(event, idx)
+        event_manager.accept_mined_seed(event, idx, chain)
 
-        seed_len = result.encoded[1]
+        seed_len = len(chain[0])
         ratio = microblock_size / seed_len if seed_len else 0
-        print(f"Microblock {idx}: depth={result.depth}, compression={ratio:.2f}x")
+        print(f"Microblock {idx}: depth={len(chain)}, compression={ratio:.2f}x")
 
     # 7. Save event to disk
     events_dir = Path("data/events")

--- a/setup_genesis.py
+++ b/setup_genesis.py
@@ -6,7 +6,7 @@ from helix.signature_utils import generate_keypair, save_keys
 from helix.ledger import save_balances
 from helix.event_manager import create_event, save_event, mark_mined
 from helix.minihelix import mine_seed
-from helix import nested_miner, miner, minihelix
+from helix import exhaustive_miner, miner, minihelix
 
 
 STATEMENT = "Helix is to data what logic is to language."
@@ -33,10 +33,10 @@ def _mine_microblocks(event: dict) -> None:
         else:
             print(f"  Flat mining failed for index {idx}, trying nested...")
             seed = None
-            result = nested_miner.find_nested_seed(block, attempts=NESTED_ATTEMPTS)
-            if result is not None:
-                chain, depth = result
+            chain = exhaustive_miner.exhaustive_mine(block)
+            if chain is not None:
                 seed = chain[0]
+                depth = len(chain)
                 if minihelix.verify_seed(seed, block):
                     print(
                         f"  Nested mining success: length {len(seed)} depth {depth}"

--- a/tests/test_cli_mine_nested.py
+++ b/tests/test_cli_mine_nested.py
@@ -17,11 +17,11 @@ def test_cli_mine_nested(tmp_path, monkeypatch):
 
     seed = b"a"
     subseed = minihelix.G(seed, 2)
-    chain = bytes([2, len(seed)]) + seed + subseed
+    chain = [seed, subseed]
 
     monkeypatch.setattr(
-        "helix.cli.nested_miner.find_nested_seed",
-        lambda block, **kwargs: (chain, 2),
+        "helix.cli.exhaustive_miner.exhaustive_mine",
+        lambda block, **kwargs: chain,
     )
     monkeypatch.setattr("helix.cli.nested_miner.verify_nested_seed", lambda c, b: True)
 
@@ -30,6 +30,4 @@ def test_cli_mine_nested(tmp_path, monkeypatch):
     reloaded = event_manager.load_event(str(tmp_path / "events" / f"{evt_id}.json"))
     assert reloaded["is_closed"]
     assert reloaded["seed_depths"][0] == 2
-    hdr = reloaded["seeds"][0][0]
-    l = reloaded["seeds"][0][1]
-    assert reloaded["seeds"][0][2 : 2 + l] == b"a"
+    assert reloaded["seeds"][0] == chain

--- a/tests/test_cli_remine_microblock.py
+++ b/tests/test_cli_remine_microblock.py
@@ -22,8 +22,8 @@ def test_remine_requires_force(tmp_path, monkeypatch):
     event = _create_event(tmp_path)
     evt_id = event["header"]["statement_id"]
 
-    chain = bytes([1, 1]) + b"a"
-    monkeypatch.setattr("helix.cli.nested_miner.find_nested_seed", lambda block, **kw: (chain, 1))
+    chain = [b"a"]
+    monkeypatch.setattr("helix.cli.exhaustive_miner.exhaustive_mine", lambda block, **kw: chain)
     monkeypatch.setattr("helix.cli.nested_miner.verify_nested_seed", lambda c, b: True)
 
     cli.main(
@@ -47,8 +47,8 @@ def test_remine_with_force(tmp_path, monkeypatch):
     event = _create_event(tmp_path)
     evt_id = event["header"]["statement_id"]
 
-    chain = bytes([1, 1]) + b"a"
-    monkeypatch.setattr("helix.cli.nested_miner.find_nested_seed", lambda block, **kw: (chain, 1))
+    chain = [b"a"]
+    monkeypatch.setattr("helix.cli.exhaustive_miner.exhaustive_mine", lambda block, **kw: chain)
     monkeypatch.setattr("helix.cli.nested_miner.verify_nested_seed", lambda c, b: True)
 
     cli.main(
@@ -64,6 +64,4 @@ def test_remine_with_force(tmp_path, monkeypatch):
         ]
     )
     reloaded = event_manager.load_event(str(tmp_path / "events" / f"{evt_id}.json"))
-    hdr = reloaded["seeds"][0][0]
-    l = reloaded["seeds"][0][1]
-    assert reloaded["seeds"][0][2 : 2 + l] == b"a"
+    assert reloaded["seeds"][0] == chain

--- a/tests/test_minihelix.py
+++ b/tests/test_minihelix.py
@@ -1,7 +1,7 @@
 import hashlib
 
 from helix import minihelix as mh
-from helix import nested_miner
+from helix import nested_miner, exhaustive_miner
 
 
 def test_G_deterministic():
@@ -26,31 +26,19 @@ def test_verify_seed_false():
 
 
 def test_find_nested_seed_simple():
-    N = 8
-    base_seed = b"abc"
+    N = 4
+    base_seed = b"a"
     inter1 = mh.G(base_seed, N)
     inter2 = mh.G(inter1, N)
     block = mh.G(inter2, N)
 
-    start_nonce = 0
-    for length in range(1, N):
-        count = 256 ** length
-        if length < len(base_seed):
-            start_nonce += count
-        elif length == len(base_seed):
-            start_nonce += int.from_bytes(base_seed, "big")
-            break
+    start_index = int.from_bytes(base_seed, "big")
 
-    result = nested_miner.find_nested_seed(
-        block, max_depth=3, start_nonce=start_nonce, attempts=1
+    chain = exhaustive_miner.exhaustive_mine(
+        block, max_depth=3, start_index=start_index
     )
-    assert result is not None, "find_nested_seed did not return a result"
-    encoded, depth = result
-    print("Returned chain", encoded, "depth", depth)
-    assert depth == 3, f"expected depth 3, got {depth}"
-    expected = bytes([3, len(base_seed)]) + base_seed + inter1 + inter2
-    assert encoded == expected, "incorrect seed encoding"
-    chain = nested_miner._decode_chain(encoded, N)
+    assert chain is not None, "exhaustive_mine did not return a result"
+    assert chain == [base_seed, inter1, inter2]
     assert nested_miner.verify_nested_seed(chain, block), "seed chain failed verification"
     print("Nested seed search SUCCESS")
 

--- a/tests/test_nested_miner.py
+++ b/tests/test_nested_miner.py
@@ -1,4 +1,4 @@
-from helix import nested_miner
+from helix import nested_miner, exhaustive_miner
 from helix import minihelix
 
 
@@ -17,12 +17,11 @@ def test_find_nested_seed_deterministic():
     intermediate = minihelix.G(base_seed, N)
     target = minihelix.G(intermediate, N)
 
-    result = nested_miner.find_nested_seed(target, max_depth=2, attempts=200)
-    assert result is not None, "find_nested_seed returned None"
+    chain = exhaustive_miner.exhaustive_mine(target, max_depth=2)
+    assert chain is not None, "exhaustive_mine returned None"
 
-    encoded, depth = result
-    chain = nested_miner._decode_chain(encoded, N)
-    assert depth == len(chain) <= 2
+    depth = len(chain)
+    assert depth <= 2
     assert nested_miner.verify_nested_seed(chain, target)
 
 

--- a/tests/test_nested_mining_node.py
+++ b/tests/test_nested_mining_node.py
@@ -28,8 +28,8 @@ def test_nested_mining_fallback(tmp_path, monkeypatch):
 
     chain = [b"a", minihelix.G(b"a", 2)]
     monkeypatch.setattr(
-        "helix.helix_node.nested_miner.find_nested_seed",
-        lambda target, max_depth: (chain, 2),
+        "helix.helix_node.exhaustive_miner.exhaustive_mine",
+        lambda target, max_depth: chain,
     )
 
     event = node.create_event("ab", private_key=None)


### PR DESCRIPTION
## Summary
- update CLI and scripts to use `exhaustive_miner.exhaustive_mine`
- adapt mining workflow across tests and helpers
- update imports and expected values in tests

## Testing
- `pip install pynacl websockets`
- `pytest -q` *(fails: genesis file hash mismatch and CLI argument errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851b4978fd48329b344f4097fffcb3c