### PR TITLE
Remove encoded seed dependence

### DIFF
--- a/helix/cli.py
+++ b/helix/cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from . import (
     event_manager,
     nested_miner,
+    exhaustive_miner,
     betting_interface,
     signature_utils,
     merkle_utils,
@@ -111,11 +112,11 @@ def cmd_mine(args: argparse.Namespace) -> None:
     for idx, block in enumerate(event.get("microblocks", [])):
         if event.get("seeds", [None])[idx] is not None:
             continue
-        result = nested_miner.find_nested_seed(block)
-        if result is None:
+        chain = exhaustive_miner.exhaustive_mine(block)
+        if chain is None:
             print(f"No seed found for block {idx}")
             continue
-        chain, _depth = result
+        _depth = len(chain)
         if not nested_miner.verify_nested_seed(chain, block):
             print(f"Verification failed for block {idx}")
             continue
@@ -130,11 +131,11 @@ def cmd_remine_microblock(args: argparse.Namespace) -> None:
         raise SystemExit("Event not found")
     event = event_manager.load_event(str(path))
     block = event["microblocks"][args.index]
-    result = nested_miner.find_nested_seed(block)
-    if result is None:
+    chain = exhaustive_miner.exhaustive_mine(block)
+    if chain is None:
         print("No seed found")
         return
-    chain, _depth = result
+    _depth = len(chain)
     if not nested_miner.verify_nested_seed(chain, block):
         print("Verification failed")
         return

--- a/helix/nested_miner.py
+++ b/helix/nested_miner.py
@@ -2,21 +2,22 @@ from __future__ import annotations
 
 """Utilities for mining nested MiniHelix seeds."""
 
-from . import minihelix
+from . import minihelix, exhaustive_miner
 from .minihelix import G, mine_seed
 
 
 class NestedSeed(bytes):
     """Representation of a mined nested seed chain."""
 
-    def __new__(cls, chain_bytes: bytes, depth: int, encoded: bytes):
+    def __new__(cls, chain_bytes: bytes, depth: int, encoded: bytes, chain: list[bytes]):
         obj = bytes.__new__(cls, chain_bytes)
         obj.depth = depth
         obj.encoded = encoded
+        obj.chain = chain
         return obj
 
     def __iter__(self):
-        yield self.encoded
+        yield self.chain
         yield self.depth
 
 
@@ -119,7 +120,7 @@ def find_nested_seed(
 
     encoded = _encode_chain(chain)
     chain_bytes = b"".join(chain)
-    return NestedSeed(chain_bytes, len(chain), encoded)
+    return NestedSeed(chain_bytes, len(chain), encoded, chain)
 
 
 def verify_nested_seed(
@@ -186,18 +187,9 @@ def hybrid_mine(
 
     Returns a ``(seed, depth)`` tuple.
     """
-    result = find_nested_seed(
-        target_block,
-        max_depth=max_depth,
-        start_nonce=0,
-        attempts=attempts or 10_000,
-        max_steps=max_steps,
-    )
-    if result is not None:
-        encoded = result.encoded
-        depth = result.depth
-        chain = _decode_chain(encoded, len(target_block))
-        return chain[0], depth
+    chain = exhaustive_miner.exhaustive_mine(target_block, max_depth=max_depth)
+    if chain is not None:
+        return chain[0], len(chain)
 
     seed = mine_seed(target_block, max_attempts=attempts)
     if seed is not None:

--- a/scripts/init_genesis.py
+++ b/scripts/init_genesis.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from helix import event_manager, signature_utils, nested_miner
+from helix import event_manager, signature_utils, nested_miner, exhaustive_miner
 
 
 def main() -> None:
@@ -32,18 +32,19 @@ def main() -> None:
 
     # 6. Mine each microblock
     for idx, block in enumerate(event["microblocks"]):
-        result = nested_miner.find_nested_seed(block, max_depth=500)
-        if result is None:
+        chain = exhaustive_miner.exhaustive_mine(block, max_depth=500)
+        if chain is None:
             print(f"Microblock {idx}: no seed found")
             continue
 
-        event["seeds"][idx] = result.encoded
-        event["seed_depths"][idx] = result.depth
+        encoded = nested_miner._encode_chain(chain)
+        event["seeds"][idx] = encoded
+        event["seed_depths"][idx] = len(chain)
         event_manager.mark_mined(event, idx)
 
-        seed_len = result.encoded[1]
+        seed_len = encoded[1]
         ratio = microblock_size / seed_len if seed_len else 0
-        print(f"Microblock {idx}: depth={result.depth}, compression={ratio:.2f}x")
+        print(f"Microblock {idx}: depth={len(chain)}, compression={ratio:.2f}x")
 
     # 7. Save event to disk
     events_dir = Path("data/events")

--- a/setup_genesis.py
+++ b/setup_genesis.py
@@ -6,7 +6,7 @@ from helix.signature_utils import generate_keypair, save_keys
 from helix.ledger import save_balances
 from helix.event_manager import create_event, save_event, mark_mined
 from helix.minihelix import mine_seed
-from helix import nested_miner, miner, minihelix
+from helix import nested_miner, miner, minihelix, exhaustive_miner
 
 
 STATEMENT = "Helix is to data what logic is to language."
@@ -33,9 +33,9 @@ def _mine_microblocks(event: dict) -> None:
         else:
             print(f"  Flat mining failed for index {idx}, trying nested...")
             seed = None
-            result = nested_miner.find_nested_seed(block, attempts=NESTED_ATTEMPTS)
-            if result is not None:
-                chain, depth = result
+            chain = exhaustive_miner.exhaustive_mine(block, max_depth=3)
+            if chain is not None:
+                depth = len(chain)
                 seed = chain[0]
                 if minihelix.verify_seed(seed, block):
                     print(

--- a/tests/test_cli_mine_nested.py
+++ b/tests/test_cli_mine_nested.py
@@ -17,11 +17,11 @@ def test_cli_mine_nested(tmp_path, monkeypatch):
 
     seed = b"a"
     subseed = minihelix.G(seed, 2)
-    chain = bytes([2, len(seed)]) + seed + subseed
+    chain = [seed, subseed]
 
     monkeypatch.setattr(
-        "helix.cli.nested_miner.find_nested_seed",
-        lambda block, **kwargs: (chain, 2),
+        "helix.cli.exhaustive_miner.exhaustive_mine",
+        lambda block, **kwargs: chain,
     )
     monkeypatch.setattr("helix.cli.nested_miner.verify_nested_seed", lambda c, b: True)
 

--- a/tests/test_cli_remine_microblock.py
+++ b/tests/test_cli_remine_microblock.py
@@ -22,8 +22,8 @@ def test_remine_requires_force(tmp_path, monkeypatch):
     event = _create_event(tmp_path)
     evt_id = event["header"]["statement_id"]
 
-    chain = bytes([1, 1]) + b"a"
-    monkeypatch.setattr("helix.cli.nested_miner.find_nested_seed", lambda block, **kw: (chain, 1))
+    chain = [b"a"]
+    monkeypatch.setattr("helix.cli.exhaustive_miner.exhaustive_mine", lambda block, **kw: chain)
     monkeypatch.setattr("helix.cli.nested_miner.verify_nested_seed", lambda c, b: True)
 
     cli.main(
@@ -47,8 +47,8 @@ def test_remine_with_force(tmp_path, monkeypatch):
     event = _create_event(tmp_path)
     evt_id = event["header"]["statement_id"]
 
-    chain = bytes([1, 1]) + b"a"
-    monkeypatch.setattr("helix.cli.nested_miner.find_nested_seed", lambda block, **kw: (chain, 1))
+    chain = [b"a"]
+    monkeypatch.setattr("helix.cli.exhaustive_miner.exhaustive_mine", lambda block, **kw: chain)
     monkeypatch.setattr("helix.cli.nested_miner.verify_nested_seed", lambda c, b: True)
 
     cli.main(

--- a/tests/test_minihelix.py
+++ b/tests/test_minihelix.py
@@ -45,12 +45,11 @@ def test_find_nested_seed_simple():
         block, max_depth=3, start_nonce=start_nonce, attempts=1
     )
     assert result is not None, "find_nested_seed did not return a result"
-    encoded, depth = result
-    print("Returned chain", encoded, "depth", depth)
+    chain, depth = result
+    print("Returned chain", chain, "depth", depth)
     assert depth == 3, f"expected depth 3, got {depth}"
-    expected = bytes([3, len(base_seed)]) + base_seed + inter1 + inter2
-    assert encoded == expected, "incorrect seed encoding"
-    chain = nested_miner._decode_chain(encoded, N)
+    expected = [base_seed, inter1, inter2]
+    assert chain == expected, "incorrect seed chain"
     assert nested_miner.verify_nested_seed(chain, block), "seed chain failed verification"
     print("Nested seed search SUCCESS")
 

--- a/tests/test_nested_miner.py
+++ b/tests/test_nested_miner.py
@@ -20,8 +20,7 @@ def test_find_nested_seed_deterministic():
     result = nested_miner.find_nested_seed(target, max_depth=2, attempts=200)
     assert result is not None, "find_nested_seed returned None"
 
-    encoded, depth = result
-    chain = nested_miner._decode_chain(encoded, N)
+    chain, depth = result
     assert depth == len(chain) <= 2
     assert nested_miner.verify_nested_seed(chain, target)
 

--- a/tests/test_nested_mining_node.py
+++ b/tests/test_nested_mining_node.py
@@ -28,8 +28,8 @@ def test_nested_mining_fallback(tmp_path, monkeypatch):
 
     chain = [b"a", minihelix.G(b"a", 2)]
     monkeypatch.setattr(
-        "helix.helix_node.nested_miner.find_nested_seed",
-        lambda target, max_depth: (chain, 2),
+        "helix.helix_node.exhaustive_miner.exhaustive_mine",
+        lambda target, **kw: chain,
     )
 
     event = node.create_event("ab", private_key=None)


### PR DESCRIPTION
## Summary
- represent mined nested seeds with explicit chains
- mine events and CLI operations using exhaustive miner
- update scripts to store encoded chains from mined lists
- refactor tests to use explicit seed chains

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: genesis file mismatch and other environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_6851b52c41248329901abd328a70d714