### PR TITLE
Add simple test runner

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Simple helper to run pytest with the repository root on PYTHONPATH.
+# Usage: ./run_tests.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export PYTHONPATH="$ROOT_DIR:${PYTHONPATH-}"
+
+pytest -vv "$@"


### PR DESCRIPTION
## Summary
- add a shell script to execute the test suite with PYTHONPATH set

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_685761e310648329aeb7cf005e231afe