### PR TITLE
Fix tests for project root PYTHONPATH

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,9 +1,5 @@
-import os
-import sys
 import pytest
 
-# Ensure project root on path when running directly
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import importlib
 

--- a/tests/test_simulate_mining.py
+++ b/tests/test_simulate_mining.py
@@ -1,9 +1,4 @@
-import os
-import sys
 import pytest
-
-# ensure project root is on path for direct execution
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 pytest.importorskip("nacl")
 


### PR DESCRIPTION
## Summary
- fix tests so they expect project root on `PYTHONPATH`

## Testing
- `pytest -k test_simulate_mining.py -q` *(fails: ModuleNotFoundError: No module named 'nacl')*

------
https://chatgpt.com/codex/tasks/task_e_685761f3b7408329938c177d9bbe39aa