### PR TITLE
Add env setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ The only external dependency at the moment is [PyNaCl](https://pypi.org/project/
 pip install pynacl
 ```
 
+### Environment Setup
+
+Before running scripts or tests, add the repository root to your `PYTHONPATH`:
+
+```bash
+source env.sh
+```
+
 ## ⚙️ Genesis Setup
 
 After installing the dependencies, create the initial keys and genesis event:

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Source this script to set PYTHONPATH to the repository root
+# Useful for running local scripts and tests.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PYTHONPATH="${SCRIPT_DIR}${PYTHONPATH:+:$PYTHONPATH}"


### PR DESCRIPTION
## Summary
- add `env.sh` to set PYTHONPATH to repo root
- document environment setup in README

## Testing
- `python run_tests.py` *(fails: SyntaxError in helix/cli.py)*

------
https://chatgpt.com/codex/tasks/task_e_685762135d9c8329b6a9f9ea41fbfcca