### PR TITLE
Ensure PyNaCl availability for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyNaCl
+pynacl
 websockets
 
 Flask

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import importlib.util
+import pytest
+
+if importlib.util.find_spec("nacl") is None:
+    raise pytest.UsageError(
+        "PyNaCl is required for the test suite. Install dependencies with 'pip install -r requirements.txt'."
+    )


### PR DESCRIPTION
## Summary
- list PyNaCl by its lowercase name so dependency resolution succeeds
- add a pytest startup check that fails when PyNaCl is missing

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: SyntaxError in helix/cli.py)*

------
https://chatgpt.com/codex/tasks/task_e_6857630eed948329833c999d67f1fd6f