### PR TITLE
Add CLI bet command

### DIFF
--- a/helix/signature_utils.py
+++ b/helix/signature_utils.py
@@ -71,6 +71,12 @@ def load_or_create_keys(filename: str) -> Tuple[str, str]:
     return pub, priv
 
 
+def load_private_key(private_key: str) -> signing.SigningKey:
+    """Return a :class:`~nacl.signing.SigningKey` for ``private_key``."""
+    key_bytes = base64.b64decode(private_key)
+    return signing.SigningKey(key_bytes)
+
+
 __all__ = [
     "generate_keypair",
     "sign_statement",
@@ -79,6 +85,7 @@ __all__ = [
     "save_keys",
     "load_keys",
     "load_or_create_keys",
+    "load_private_key",
 ]
 
 


### PR DESCRIPTION
## Summary
- support loading an Ed25519 private key from a base64 string
- add `place_bet` helper to submit a YES/NO bet
- wire `bet` subcommand into `helix_cli`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cad3daaf48329a3092e5a418c4480