### PR TITLE
Add vote header tests

### DIFF
--- a/helix/__init__.py
+++ b/helix/__init__.py
@@ -6,13 +6,16 @@ _GENESIS_SRC = Path(__file__).with_name("genesis.json")
 
 _ORIG_READ_BYTES = Path.read_bytes
 
+
 def _patched_read_bytes(self: Path) -> bytes:  # type: ignore[override]
     if not self.is_absolute() and self.name == "genesis.json" and not self.exists():
         if _GENESIS_SRC.exists():
             return _GENESIS_SRC.read_bytes()
     return _ORIG_READ_BYTES(self)
 
+
 Path.read_bytes = _patched_read_bytes
+
 
 def _ensure_local_genesis() -> None:
     dest = Path("genesis.json")
@@ -22,4 +25,12 @@ def _ensure_local_genesis() -> None:
         except Exception:
             pass
 
+
 _ensure_local_genesis()
+
+from .vote_header import encode_vote_header, decode_vote_header
+
+__all__ = [
+    "encode_vote_header",
+    "decode_vote_header",
+]

--- a/helix/vote_header.py
+++ b/helix/vote_header.py
@@ -1,0 +1,37 @@
+VOTE_SCALE = 100
+
+
+def encode_vote_header(yes: float, no: float) -> bytes:
+    """Encode YES and NO vote amounts into a variable-length header."""
+    yes_int = round(yes * VOTE_SCALE)
+    no_int = round(no * VOTE_SCALE)
+    if not (0 <= yes_int <= 0xFFFFFFFF):
+        raise ValueError("YES value out of range")
+    if not (0 <= no_int <= 0xFFFFFFFF):
+        raise ValueError("NO value out of range")
+    yes_len = max(1, (yes_int.bit_length() + 7) // 8)
+    no_len = max(1, (no_int.bit_length() + 7) // 8)
+    return (
+        bytes([yes_len, no_len])
+        + yes_int.to_bytes(yes_len, "big")
+        + no_int.to_bytes(no_len, "big")
+    )
+
+
+def decode_vote_header(data: bytes) -> tuple[float, float]:
+    """Decode YES and NO vote amounts from a header created by ``encode_vote_header``."""
+    if len(data) < 2:
+        raise ValueError("header too short")
+    yes_len = data[0]
+    no_len = data[1]
+    if yes_len == 0 or no_len == 0:
+        raise ValueError("invalid lengths")
+    expect_len = 2 + yes_len + no_len
+    if len(data) < expect_len:
+        raise ValueError("header truncated")
+    yes_int = int.from_bytes(data[2 : 2 + yes_len], "big")
+    no_int = int.from_bytes(data[2 + yes_len : expect_len], "big")
+    return yes_int / VOTE_SCALE, no_int / VOTE_SCALE
+
+
+__all__ = ["encode_vote_header", "decode_vote_header"]

--- a/tests/test_vote_header.py
+++ b/tests/test_vote_header.py
@@ -1,0 +1,40 @@
+import pytest
+
+from helix.vote_header import encode_vote_header, decode_vote_header
+
+
+def test_examples():
+    hdr = encode_vote_header(12.34, 56.78)
+    assert hdr == bytes([2, 2, 0x04, 0xD2, 0x16, 0x2E])
+    yes, no = decode_vote_header(hdr)
+    assert yes == pytest.approx(12.34)
+    assert no == pytest.approx(56.78)
+
+    hdr = encode_vote_header(0.01, 0.01)
+    assert hdr == bytes([1, 1, 0x01, 0x01])
+    assert decode_vote_header(hdr) == pytest.approx((0.01, 0.01))
+
+    max_yes = 42949672.95
+    hdr = encode_vote_header(max_yes, 0)
+    assert hdr == bytes([4, 1, 0xFF, 0xFF, 0xFF, 0xFF, 0x00])
+    yes, no = decode_vote_header(hdr)
+    assert yes == pytest.approx(max_yes)
+    assert no == pytest.approx(0)
+
+
+def test_all_bit_lengths():
+    for yes_bits in range(1, 33):
+        yes_val = (1 << yes_bits) - 1
+        yes_amt = yes_val / 100
+        yes_len = max(1, (yes_bits + 7) // 8)
+        for no_bits in range(1, 33):
+            no_val = (1 << no_bits) - 1
+            no_amt = no_val / 100
+            no_len = max(1, (no_bits + 7) // 8)
+            hdr = encode_vote_header(yes_amt, no_amt)
+            assert hdr[0] == yes_len
+            assert hdr[1] == no_len
+            assert len(hdr) == 2 + yes_len + no_len
+            y, n = decode_vote_header(hdr)
+            assert y == pytest.approx(yes_amt)
+            assert n == pytest.approx(no_amt)


### PR DESCRIPTION
## Summary
- add `encode_vote_header`/`decode_vote_header` helpers
- test binary encoding and decoding of YES/NO vote headers

## Testing
- `./run_tests.sh` *(fails: argparse.ArgumentError: argument command: conflicting subparser: doctor)*

------
https://chatgpt.com/codex/tasks/task_e_686222ac8d248329b39597eb45e1f6f2