### PR TITLE
Add finalized block gossip support

### DIFF
--- a/helix/gossip.py
+++ b/helix/gossip.py
@@ -58,6 +58,7 @@ class LocalGossipNetwork:
             "EVENT_FINALIZED",
             "FINALIZED",
             "FINALIZED_BLOCK",
+            "finalized_block",
         }
         if log:
             print(f"{sender_id} broadcasting {msg_type}")
@@ -145,6 +146,14 @@ class GossipNode:
     def broadcast_block(self, block: Dict[str, Any]) -> None:
         """Broadcast a finalized block to peers."""
         self.send_message({"type": "FINALIZED_BLOCK", "block": block})
+
+    def broadcast_finalized_block(self, event_id: str, block_header: Dict[str, Any]) -> None:
+        """Broadcast a finalized block header for ``event_id``."""
+        self.send_message({
+            "type": "finalized_block",
+            "event_id": event_id,
+            "block_header": block_header,
+        })
 
     def _validate_block(self, block: Dict[str, Any]) -> bool:
         """Return ``True`` if ``block`` correctly links to local chain."""

--- a/helix/helix_node.py
+++ b/helix/helix_node.py
@@ -38,6 +38,7 @@ class GossipMessageType:
     MINED_MICROBLOCK = "MINED_MICROBLOCK"
     FINALIZED = "FINALIZED"
     FINALIZED_BLOCK = "FINALIZED_BLOCK"
+    FINALIZED_BLOCK_HEADER = "finalized_block"
     CHAIN_TIP = "CHAIN_TIP"
     CHAIN_REQUEST = "CHAIN_REQUEST"
     CHAIN_RESPONSE = "CHAIN_RESPONSE"
@@ -282,12 +283,25 @@ class HelixNode(GossipNode):
         self.save_state()
 
     def finalize_event(self, event: Dict[str, Any]) -> Dict[str, float]:
+        before = bc.load_chain(str(self.chain_file))
         payouts = event_manager.finalize_event(
             event,
             node_id=self.node_id,
             chain_file=str(self.chain_file),
             balances_file=str(self.balances_file),
         )
+        chain_after = bc.load_chain(str(self.chain_file))
+        if len(chain_after) > len(before):
+            block_header = chain_after[-1]
+            self.blockchain = chain_after
+            evt_id = event["header"]["statement_id"]
+            self.send_message(
+                {
+                    "type": GossipMessageType.FINALIZED_BLOCK_HEADER,
+                    "event_id": evt_id,
+                    "block_header": block_header,
+                }
+            )
         self.balances = load_balances(str(self.balances_file))
         self.save_state()
         self.send_message({"type": GossipMessageType.FINALIZED, "event": event})
@@ -364,6 +378,17 @@ class HelixNode(GossipNode):
         elif mtype == GossipMessageType.FINALIZED_BLOCK:
             block = message.get("block")
             if block and self.apply_block(block):
+                self.forward_message(message)
+        elif mtype == GossipMessageType.FINALIZED_BLOCK_HEADER:
+            evt_id = message.get("event_id")
+            block = message.get("block_header")
+            if not evt_id or not isinstance(block, dict):
+                return
+            if evt_id not in self.events:
+                # unknown event; propagate request if fetch mechanism exists
+                self.forward_message(message)
+                return
+            if self.apply_block(block):
                 self.forward_message(message)
 
     def _message_loop(self) -> None:


### PR DESCRIPTION
## Summary
- enable nodes to gossip finalized block headers
- broadcast finalized block when events are finalized
- handle incoming finalized block messages

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError NameError in event_manager)*

------
https://chatgpt.com/codex/tasks/task_e_68631942409c8329bfcff82acde3f28b