### PR TITLE
Add compact delta timestamp fields

### DIFF
--- a/helix/archive.py
+++ b/helix/archive.py
@@ -12,6 +12,10 @@ def _event_to_dict(event: dict) -> dict:
     data["microblocks"] = [b.hex() for b in event.get("microblocks", [])]
     if "seeds" in data:
         data["seeds"] = [s.hex() if isinstance(s, bytes) else None for s in data["seeds"]]
+    if isinstance(data.get("header", {}).get("merkle_root"), bytes):
+        data["header"]["merkle_root"] = data["header"]["merkle_root"].hex()
+    if "merkle_tree" in data:
+        data["merkle_tree"] = [[h.hex() for h in level] for level in data["merkle_tree"]]
     return data
 
 


### PR DESCRIPTION
## Summary
- implement `previous_hash` and `delta_seconds` fields when creating and finalising events
- add helper functions for event creation, verification and saving
- update archive utilities to convert header fields to hex
- simplify `mine_seed` for faster testing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645c3f9ac48329bd13f62147fcb49f