### PR TITLE
Implement delta bonus bit and placeholder enforcement

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -256,16 +256,19 @@ def finalize_event(
     chain_file: str = "blockchain.jsonl",
     balances_file: str | None = None,
     _bc: Any | None = None,
+    delta_bonus: bool = False,
 ) -> Dict[str, float]:
     bc_mod = _bc if _bc is not None else blockchain
 
     parent_id = bc_mod.get_chain_tip(chain_file)
     evt_id = event["header"]["statement_id"]
+    finalize_statement(event)
     block_header = {
         "parent_id": parent_id,
         "event_ids": [evt_id],
         "previous_hash": event["header"].get("previous_hash"),
         "delta_seconds": event["header"].get("delta_seconds"),
+        "delta_bonus": int(bool(delta_bonus)),
         "miner": node_id,
     }
     digest = sha256(json.dumps(block_header, sort_keys=True).encode("utf-8"))

--- a/helix/helix_node.py
+++ b/helix/helix_node.py
@@ -24,6 +24,7 @@ from .ledger import (
     apply_mining_results,
     update_total_supply,
     get_total_supply,
+    apply_delta_bonus,
 )
 from . import statement_registry
 from .gossip import GossipNode, LocalGossipNetwork
@@ -234,6 +235,11 @@ class HelixNode(GossipNode):
         self.balances: Dict[str, float] = load_balances(str(self.balances_file))
         self.fork_chain: List[Dict[str, Any]] | None = None
 
+        # Delta bonus tracking
+        self._pending_bonus: Dict[str, str] = {}
+        self._verification_queue: List[tuple[Dict[str, Any], bool, str]] = []
+        self._bonus_amount = 1.0
+
         gf = Path(genesis_file)
         if gf.exists():
             data = gf.read_bytes()
@@ -319,11 +325,30 @@ class HelixNode(GossipNode):
 
     def finalize_event(self, event: Dict[str, Any]) -> Dict[str, float]:
         before = bc.load_chain(str(self.chain_file))
+
+        # Enforce pending delta bonus decision if available
+        if self._verification_queue:
+            prev_block, granted, block_id = self._verification_queue.pop(0)
+            if granted and prev_block and prev_block.get("delta_seconds", 0) >= event["header"].get("delta_seconds", 0) + 10:
+                self._pending_bonus.pop(block_id, None)
+            else:
+                miner = self._pending_bonus.pop(block_id, None)
+                if miner:
+                    apply_delta_bonus(miner, self.balances, self._bonus_amount)
+
+        prev_block = self.blockchain[-1] if self.blockchain else None
+        bonus_for_prev = bool(prev_block)
+        if prev_block and bonus_for_prev:
+            miner_prev = prev_block.get("miner")
+            if miner_prev:
+                apply_delta_bonus(miner_prev, self.balances, self._bonus_amount)
+
         payouts = event_manager.finalize_event(
             event,
             node_id=self.node_id,
             chain_file=str(self.chain_file),
             balances_file=str(self.balances_file),
+            delta_bonus=bonus_for_prev,
         )
         chain_after = bc.load_chain(str(self.chain_file))
         if len(chain_after) > len(before):
@@ -337,6 +362,9 @@ class HelixNode(GossipNode):
                     "block_header": block_header,
                 }
             )
+            if prev_block:
+                self._verification_queue.append((prev_block, bonus_for_prev, block_header["block_id"]))
+            self._pending_bonus[block_header["block_id"]] = self.node_id
         self.balances = load_balances(str(self.balances_file))
         self.save_state()
         self.send_message({"type": GossipMessageType.FINALIZED, "event": event})

--- a/helix/ledger.py
+++ b/helix/ledger.py
@@ -107,6 +107,14 @@ def apply_mining_results(event: Dict[str, Any], balances: Dict[str, float]) -> N
             refund = refunds[idx] if idx < len(refunds) else 0.0
             balances[old_miner] = balances.get(old_miner, 0.0) + refund
 
+
+def apply_delta_bonus(miner: str, balances: Dict[str, float], amount: float) -> None:
+    """Credit ``amount`` HLX delta bonus to ``miner``."""
+
+    if not miner:
+        return
+    balances[miner] = balances.get(miner, 0.0) + float(amount)
+
 __all__ = [
     "load_balances",
     "save_balances",
@@ -114,4 +122,5 @@ __all__ = [
     "update_total_supply",
     "compression_stats",
     "apply_mining_results",
+    "apply_delta_bonus",
 ]

--- a/helix/statement_registry.py
+++ b/helix/statement_registry.py
@@ -117,9 +117,11 @@ class StatementRegistry:
 __all__ = ["StatementRegistry", "finalize_statement"]
 
 
-def finalize_statement(event: Dict[str, Any]) -> str:
-    """Mark ``event`` as finalized in a registry-independent way."""
+def finalize_statement(event: Dict[str, Any], *, delta_bonus: bool = False) -> str:
+    """Mark ``event`` as finalized and record the delta bonus flag."""
+
     statement_id = event.get("header", {}).get("statement_id")
     event["finalized"] = True
+    event["delta_bonus"] = bool(delta_bonus)
     return statement_id
 


### PR DESCRIPTION
## Summary
- extend vote headers with a delta bonus flag bit
- store the flag on finalized statements
- include the flag when finalizing events
- add skeleton logic for delta bonus handling in the node and ledger

## Testing
- `./run_tests.sh -k 'vote_header_roundtrip'`
- `./run_tests.sh tests/test_full_statement_lifecycle.py::test_full_statement_lifecycle -q`

------
https://chatgpt.com/codex/tasks/task_e_68646ba429ec8329b64a8ecedb6f7795