### PR TITLE
Remove import side effects for safe testing

### DIFF
--- a/helix/__init__.py
+++ b/helix/__init__.py
@@ -1,33 +1,3 @@
-"""Helix package initialization."""
-
-from pathlib import Path
-
-_GENESIS_SRC = Path(__file__).with_name("genesis.json")
-
-_ORIG_READ_BYTES = Path.read_bytes
-
-
-def _patched_read_bytes(self: Path) -> bytes:  # type: ignore[override]
-    if not self.is_absolute() and self.name == "genesis.json" and not self.exists():
-        if _GENESIS_SRC.exists():
-            return _GENESIS_SRC.read_bytes()
-    return _ORIG_READ_BYTES(self)
-
-
-Path.read_bytes = _patched_read_bytes
-
-
-def _ensure_local_genesis() -> None:
-    dest = Path("genesis.json")
-    if not dest.exists() and _GENESIS_SRC.exists():
-        try:
-            dest.write_bytes(_GENESIS_SRC.read_bytes())
-        except Exception:
-            pass
-
-
-_ensure_local_genesis()
-
 from .vote_header import encode_vote_header, decode_vote_header
 from .batch_reassembler import reassemble_statement
 


### PR DESCRIPTION
## Summary
- simplify `helix/__init__.py` to avoid disk patching
- keep package markers for `helix` and `tests`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest tests/test_minihelix.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68648bc7f2548329917bc1fcc7c1449b