### PR TITLE
Add helix_validator script and Merkle utilities

### DIFF
--- a/helix/merkle_utils.py
+++ b/helix/merkle_utils.py
@@ -1,0 +1,58 @@
+import hashlib
+from typing import List, Tuple
+
+
+def _hash(data: bytes) -> bytes:
+    """Return SHA256 digest of ``data``."""
+    return hashlib.sha256(data).digest()
+
+
+def build_merkle_tree(microblocks: List[bytes]) -> Tuple[bytes, List[List[bytes]]]:
+    """Return the Merkle root and full tree for ``microblocks``."""
+    if not microblocks:
+        return b"", []
+
+    level: List[bytes] = [_hash(b) for b in microblocks]
+    tree: List[List[bytes]] = [level]
+
+    while len(level) > 1:
+        next_level: List[bytes] = []
+        for i in range(0, len(level), 2):
+            left = level[i]
+            right = level[i + 1] if i + 1 < len(level) else left
+            next_level.append(_hash(left + right))
+        tree.append(next_level)
+        level = next_level
+
+    root = level[0]
+    return root, tree
+
+
+def generate_merkle_proof(index: int, tree: List[List[bytes]]) -> List[bytes]:
+    """Return the Merkle proof for the leaf at ``index`` using ``tree``."""
+    proof: List[bytes] = []
+    for level in tree[:-1]:
+        sibling_idx = index ^ 1
+        if sibling_idx < len(level):
+            proof.append(level[sibling_idx])
+        index //= 2
+    return proof
+
+
+def verify_merkle_proof(leaf: bytes, proof: List[bytes], root: bytes, index: int) -> bool:
+    """Return ``True`` if ``proof`` authenticates ``leaf`` against ``root``."""
+    computed = _hash(leaf)
+    for sibling in proof:
+        if index % 2 == 0:
+            computed = _hash(computed + sibling)
+        else:
+            computed = _hash(sibling + computed)
+        index //= 2
+    return computed == root
+
+
+__all__ = [
+    "build_merkle_tree",
+    "generate_merkle_proof",
+    "verify_merkle_proof",
+]

--- a/helix_validator.py
+++ b/helix_validator.py
@@ -1,0 +1,108 @@
+import argparse
+import hashlib
+from pathlib import Path
+from typing import Any, List
+
+from helix import event_manager, minihelix, nested_miner
+from helix.merkle_utils import build_merkle_tree
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _parse_seed(encoded: bytes) -> bytes:
+    """Return the base seed from encoded seed chain bytes."""
+    if not encoded or len(encoded) < 2:
+        return b""
+    seed_len = encoded[1]
+    return encoded[2 : 2 + seed_len]
+
+
+def validate_event(event: dict[str, Any]) -> dict[str, Any]:
+    micro_size = event["header"].get("microblock_size", minihelix.DEFAULT_MICROBLOCK_SIZE)
+    block_count = event["header"].get("block_count", len(event.get("seeds", [])))
+
+    reconstructed_blocks: List[bytes] = []
+    seed_valid = True
+    bad_index: int | None = None
+    for idx in range(block_count):
+        enc = event.get("seeds", [None])[idx]
+        if enc is None:
+            seed_valid = False
+            bad_index = idx
+            break
+        seed = _parse_seed(enc)
+        block = minihelix.G(seed, micro_size)
+        if not nested_miner.verify_nested_seed(enc, block):
+            seed_valid = False
+            bad_index = idx
+            break
+        reconstructed_blocks.append(block)
+
+    statement_bytes = b"".join(reconstructed_blocks).rstrip(b"\x00")
+    statement = statement_bytes.decode("utf-8", errors="replace")
+
+    stmt_match = statement == event.get("statement", "")
+    hash_match = sha256_hex(statement_bytes) == event.get("header", {}).get("statement_id")
+
+    root, tree = build_merkle_tree(reconstructed_blocks)
+    hdr_root = event.get("header", {}).get("merkle_root")
+    merkle_match = hdr_root == root
+    if merkle_match and event.get("merkle_tree"):
+        merkle_match = tree == event["merkle_tree"]
+
+    orig_bytes = micro_size * block_count
+    comp_bytes = sum(len(s) for s in event.get("seeds", []) if s is not None)
+    reduction = 100.0 * (1 - (comp_bytes / orig_bytes)) if orig_bytes else 0.0
+
+    return {
+        "statement": statement,
+        "statement_match": stmt_match,
+        "hash_match": hash_match,
+        "merkle_match": merkle_match,
+        "seed_valid": seed_valid,
+        "bad_index": bad_index,
+        "orig_bytes": orig_bytes,
+        "comp_bytes": comp_bytes,
+        "reduction": reduction,
+        "block_count": block_count,
+        "statement_id": event.get("header", {}).get("statement_id"),
+    }
+
+
+def print_summary(result: dict[str, Any]) -> None:
+    status = "✓" if all(
+        [result["statement_match"], result["hash_match"], result["merkle_match"], result["seed_valid"]]
+    ) else "✗"
+    print(f"[{status}] Statement ID: {result['statement_id']}")
+    print(f"    Microblocks: {result['block_count']}")
+    print(f"    Reconstructed: {'✔' if result['statement_match'] else '✖'}")
+    print(f"    Merkle Verified: {'✔' if result['merkle_match'] else '✖'}")
+    print(f"    Seed Chain Valid: {'✔' if result['seed_valid'] else '✖'}")
+    if not result['seed_valid'] and result['bad_index'] is not None:
+        print(f"        Failed at microblock {result['bad_index']}")
+    print(
+        f"    Compression: {result['orig_bytes']} → {result['comp_bytes']} bytes ({result['reduction']:.1f}%)"
+    )
+    if not result["hash_match"]:
+        print("    Statement hash mismatch")
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Validate finalized Helix event")
+    parser.add_argument("event_id", help="Event identifier")
+    parser.add_argument("--events-dir", default="data/events", help="Events directory")
+    args = parser.parse_args(argv)
+
+    path = Path(args.events_dir) / f"{args.event_id}.json"
+    if not path.exists():
+        raise SystemExit("Event file not found")
+
+    event = event_manager.load_event(str(path))
+    result = validate_event(event)
+    print_summary(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- restore `merkle_utils` module with hash, tree and proof helpers
- introduce `helix_validator.py` tool for verifying finalized events

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_6864a7d317dc8329ae5c01ad69be9de3