### PR TITLE
Finalize MVP tie-breaking and mint validation

### DIFF
--- a/chain_validator.py
+++ b/chain_validator.py
@@ -1,14 +1,100 @@
 import json
 import hashlib
+import time
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Iterable
 
 from helix import minihelix, blockchain, event_manager
-from helix.ledger import load_balances
+from helix.ledger import load_balances, update_total_supply
 
 
 def sha256_hex(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
+
+
+def _pubkey_hash(pub: str | bytes) -> str:
+    """Return hex SHA-256 hash of ``pub``."""
+    if isinstance(pub, str):
+        pub = pub.encode("utf-8")
+    return sha256_hex(pub)
+
+
+def resolve_seed_collision(current: Dict[str, Any] | None, challenger: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the canonical seed info between ``current`` and ``challenger``.
+
+    Each mapping must contain ``seed`` (bytes), ``delta_seconds`` (float), and
+    ``pubkey`` (str).  ``current`` may be ``None`` indicating no existing seed.
+    The function returns the preferred mapping according to canonical
+    tie–breaking rules.
+    """
+
+    if current is None:
+        return challenger
+
+    a, b = current, challenger
+
+    # shorter seed wins
+    if len(b["seed"]) < len(a["seed"]):
+        return b
+    if len(b["seed"]) > len(a["seed"]):
+        return a
+
+    # lower delta_seconds wins
+    if b["delta_seconds"] < a["delta_seconds"]:
+        return b
+    if b["delta_seconds"] > a["delta_seconds"]:
+        return a
+
+    # lower pubkey hash wins
+    ph_a = _pubkey_hash(a["pubkey"])
+    ph_b = _pubkey_hash(b["pubkey"])
+    if ph_b < ph_a:
+        return b
+    if ph_b > ph_a:
+        return a
+
+    # lexicographically lower seed hash wins
+    sh_a = sha256_hex(a["seed"])
+    sh_b = sha256_hex(b["seed"])
+    if sh_b < sh_a:
+        return b
+    return a
+
+
+def validate_and_mint(
+    seed: bytes,
+    microblock: bytes,
+    wallet: str,
+    block_hash: str,
+    *,
+    journal_path: str = "ledger_journal.jsonl",
+    supply_path: str = "supply.json",
+) -> float:
+    """Mint HLX for valid compression proof and log the event.
+
+    Returns the minted amount.
+    """
+
+    if minihelix.G(seed, len(microblock)) != microblock:
+        raise ValueError("invalid seed for microblock")
+    if len(seed) >= len(microblock):
+        raise ValueError("seed does not achieve compression")
+
+    amount = float(len(microblock) - len(seed))
+
+    entry = {
+        "action": "mint",
+        "reason": "compression_reward",
+        "wallet": wallet,
+        "block": block_hash,
+        "timestamp": int(time.time()),
+        "amount": amount,
+    }
+    with open(journal_path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+    update_total_supply(amount, path=supply_path)
+    return amount
 
 
 def verify_block_hash(block: Dict[str, Any], parent_id: str | None) -> None:

--- a/tests/test_chain_validator_mvp.py
+++ b/tests/test_chain_validator_mvp.py
@@ -1,0 +1,39 @@
+import json
+import pytest
+
+import chain_validator as cv
+from helix import minihelix
+
+
+def test_tiebreak_delta_equal():
+    a = {"seed": b"a", "delta_seconds": 1.0, "pubkey": "b"}
+    b = {"seed": b"b", "delta_seconds": 1.0, "pubkey": "a"}
+    winner = cv.resolve_seed_collision(a, b)
+    assert winner is a
+
+
+def test_tiebreak_pubkey_equal():
+    a = {"seed": b"b", "delta_seconds": 1.0, "pubkey": "a"}
+    c = {"seed": b"a", "delta_seconds": 1.0, "pubkey": "a"}
+    winner = cv.resolve_seed_collision(a, c)
+    assert winner is a
+
+
+def test_validate_and_mint(tmp_path):
+    micro = minihelix.G(b"a", 3)
+    journal = tmp_path / "ledger_journal.jsonl"
+    supply = tmp_path / "supply.json"
+    amount = cv.validate_and_mint(b"a", micro, "alice", "block1", journal_path=str(journal), supply_path=str(supply))
+    assert amount == 2.0
+    with open(journal, "r", encoding="utf-8") as fh:
+        line = json.loads(fh.readline())
+    assert line["wallet"] == "alice"
+    assert line["amount"] == amount
+    with open(supply, "r", encoding="utf-8") as fh:
+        total = json.load(fh)["total"]
+    assert total == amount
+
+    # invalid seed should raise
+    with pytest.raises(ValueError):
+        cv.validate_and_mint(b"aaa", micro, "alice", "block1", journal_path=str(journal), supply_path=str(supply))
+


### PR DESCRIPTION
## Summary
- implement canonical seed tie-breaking logic
- add `validate_and_mint` helper with journal logging
- write tests for tie-breaking and mint validation

## Testing
- `pytest tests/test_chain_validator_mvp.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6864ad6dab1c8329b38b79155d257537