### PR TITLE
Implement ledger journal for secure minting

### DIFF
--- a/helix/helix_node.py
+++ b/helix/helix_node.py
@@ -21,7 +21,6 @@ from .ledger import (
     load_balances,
     save_balances,
     apply_mining_results,
-    update_total_supply,
     get_total_supply,
     apply_delta_bonus,
 )
@@ -450,7 +449,6 @@ class HelixNode(GossipNode):
             if event:
                 evt_id = event["header"]["statement_id"]
                 self.events[evt_id] = event
-                update_total_supply(event.get("miner_reward", 0.0))
                 apply_mining_results(event, self.balances)
                 for acct, amt in event.get("payouts", {}).items():
                     self.balances[acct] = self.balances.get(acct, 0.0) + amt

--- a/tests/test_ledger_journal.py
+++ b/tests/test_ledger_journal.py
@@ -1,0 +1,31 @@
+import json
+import hashlib
+from chain_validator import validate_and_mint
+
+
+def _make_block(parent: str | None = None) -> dict:
+    body = {"parent_id": parent}
+    digest = hashlib.sha256(json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+    body["block_id"] = digest
+    return body
+
+
+def test_mint_logs_entry(tmp_path):
+    block = _make_block()
+    journal = tmp_path / "ledger_journal.jsonl"
+    supply = tmp_path / "supply.json"
+
+    validate_and_mint(block, "WALLET", 5.0, "test", supply_file=str(supply), journal_file=str(journal))
+
+    data = journal.read_text().strip().splitlines()
+    assert len(data) == 1
+    entry = json.loads(data[0])
+    assert entry["action"] == "mint"
+    assert entry["wallet"] == "WALLET"
+    assert entry["amount"] == 5.0
+    assert entry["reason"] == "test"
+    assert entry["block"] == block["block_id"]
+    assert isinstance(entry["timestamp"], int)
+
+    total = json.load(open(supply))
+    assert total["total"] == 5.0


### PR DESCRIPTION
## Summary
- log ledger events to a new `ledger_journal.jsonl`
- restrict total supply updates to `chain_validator.validate_and_mint`
- add `validate_and_mint` to record a journal entry and mint tokens
- adjust Helix node imports
- test mint logging

## Testing
- `pytest -q tests/test_ledger_journal.py`

------
https://chatgpt.com/codex/tasks/task_e_6864ad767bf083298d922293f1fe96d2