### PR TITLE
Update test execution docs and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ python setup_genesis.py
 
 This mines the genesis microblocks and writes the results into the `data/` directory.
 
+## 🧪 Running Tests
+
+Execute the full test suite from the repository root using `pytest`:
+
+```bash
+pytest -v --tb=short tests/
+```
+
+Running individual test files via `python test_*.py` can break imports and is
+not supported.
+
 ## ❓ Troubleshooting
 
 - **`ModuleNotFoundError: No module named 'nacl'`**

--- a/run_tests.py
+++ b/run_tests.py
@@ -39,7 +39,12 @@ def reset_test_dirs() -> None:
 
 def run_pytest() -> int:
     """Run pytest and print a simple summary."""
-    proc = subprocess.run(["pytest", "-vv"], capture_output=True, text=True)
+    proc = subprocess.run([
+        "pytest",
+        "-v",
+        "--tb=short",
+        "tests/",
+    ], capture_output=True, text=True)
     print(proc.stdout)
     if proc.stderr:
         print(proc.stderr, file=sys.stderr)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -7,4 +7,4 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 export PYTHONPATH="$ROOT_DIR:${PYTHONPATH-}"
 
-pytest -vv "$@"
+pytest -v --tb=short tests/


### PR DESCRIPTION
## Summary
- document how to run tests correctly with pytest
- use `pytest -v --tb=short tests/` in helper scripts

## Testing
- `pytest -v --tb=short tests/` *(fails: 29 failed, 40 passed, 29 skipped)*
- `bash run_tests.sh` *(fails: 29 failed, 40 passed, 29 skipped)*
- `python run_tests.py` *(fails: 29 failed, 40 passed, 29 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6864b15b5b648329be0b587e49ad6ac8