### PR TITLE
Add coverage reporting to tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+source = helix
+
+[report]
+omit =
+    tests/*
+    */__init__.py
+exclude_lines =
+    pragma: no cover

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+.coverage
+coverage.xml

--- a/README.md
+++ b/README.md
@@ -85,6 +85,23 @@ python setup_genesis.py
 
 This mines the genesis microblocks and writes the results into the `data/` directory.
 
+## ✅ Running Tests & Coverage
+
+Install the test dependencies and execute the suite with coverage:
+
+```bash
+python3 -m pip install -r requirements.txt
+./run_tests.sh
+```
+
+Set `COV_FAIL_UNDER` to fail the run if coverage drops below a threshold (in percent):
+
+```bash
+COV_FAIL_UNDER=85 ./run_tests.sh
+```
+
+This runs `pytest --cov=helix tests/` and prints a coverage report to stdout.
+
 ## ❓ Troubleshooting
 
 - **`ModuleNotFoundError: No module named 'nacl'`**

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pynacl
 websockets
 
 Flask
+pytest
+pytest-cov

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,4 +1,5 @@
 import importlib.util
+import os
 import shutil
 import subprocess
 import sys
@@ -38,8 +39,11 @@ def reset_test_dirs() -> None:
 
 
 def run_pytest() -> int:
-    """Run pytest and print a simple summary."""
-    proc = subprocess.run(["pytest", "-vv"], capture_output=True, text=True)
+    """Run pytest with coverage and print a simple summary."""
+    cmd = ["pytest", "-vv", "--cov=helix", "tests/"]
+    if os.getenv("COV_FAIL_UNDER"):
+        cmd.append(f"--cov-fail-under={os.environ['COV_FAIL_UNDER']}")
+    proc = subprocess.run(cmd, capture_output=True, text=True)
     print(proc.stdout)
     if proc.stderr:
         print(proc.stderr, file=sys.stderr)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -7,4 +7,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 export PYTHONPATH="$ROOT_DIR:${PYTHONPATH-}"
 
-pytest -vv "$@"
+COV_ARGS="--cov=helix --cov-report=term"
+if [[ -n "${COV_FAIL_UNDER:-}" ]]; then
+  COV_ARGS+=" --cov-fail-under=${COV_FAIL_UNDER}"
+fi
+
+pytest -vv ${COV_ARGS} tests/ "$@"


### PR DESCRIPTION
## Summary
- integrate `pytest-cov` in `run_tests.sh` and `run_tests.py`
- track coverage settings in `.coveragerc`
- ignore coverage artifacts in `.gitignore`
- document how to run tests with coverage in `README`
- include `pytest` and `pytest-cov` in requirements

## Testing
- `pip install -r requirements.txt`
- `./run_tests.sh` *(fails: 29 failed, 40 passed, 29 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6864b18377ac8329824ccb4ee8f7e973