### PR TITLE
Make tests deterministic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,20 @@
 import importlib.util
+import os
+import random
+import time
 import pytest
 
 if importlib.util.find_spec("nacl") is None:
     raise pytest.UsageError(
         "PyNaCl is required for the test suite. Install dependencies with 'pip install -r requirements.txt'."
     )
+
+
+@pytest.fixture(autouse=True)
+def _deterministic(monkeypatch):
+    """Provide deterministic OS, random and time functions for tests."""
+
+    monkeypatch.setattr(random, "random", lambda: 0.0)
+    monkeypatch.setattr(random, "randint", lambda a, b: a)
+    monkeypatch.setattr(os, "urandom", lambda n: b"\0" * n)
+    monkeypatch.setattr(time, "time", lambda: 1_700_000_000.0)


### PR DESCRIPTION
## Summary
- add autouse fixture to force deterministic return values for `random`, `os.urandom` and `time.time`

## Testing
- `pytest tests/test_miner.py::test_generate_microblock -q`
- `pytest tests/test_helix_cli_mine_benchmark.py::test_mine_benchmark -q`
- `pytest -q` *(fails: exhaustive miner functions missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864b1a6dec883299945de14b222693c