### PR TITLE
Switch G to streamed hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Unlike legacy blockchains that mint tokens by wasting computation, Helix mints 1
 🧠 **Compression = Proof-of-Work**  
 - All submitted claims are grouped into **microblocks**.  
 - Miners compete to find the **smallest seed** that regenerates the exact block output using a deterministic hash-based function:  
-  `G(s) = Truncate_N(H(s || len(s)))`  
+  `G(s) = (SHA256(s || 0) || SHA256(s || 1) || …)[:N]`
 - The smaller the seed, the more compression—and the more HLX earned.
 
 🧮 **Transparent Incentives**  

--- a/helix/miner.py
+++ b/helix/miner.py
@@ -2,17 +2,23 @@ import hashlib
 import os
 import random
 
+from .minihelix import DEFAULT_MICROBLOCK_SIZE
+
 
 def truncate_hash(data: bytes, length: int) -> bytes:
     """Return the first `length` bytes of SHA256(data)."""
     return hashlib.sha256(data).digest()[:length]
 
 
-def generate_microblock(seed: bytes) -> bytes:
-    """Return microblock for a given seed using G(s) = Truncate_N(H(s || len(s)))."""
-    length = len(seed)
-    input_data = seed + length.to_bytes(4, "big")
-    return hashlib.sha256(input_data).digest()
+def generate_microblock(seed: bytes, block_size: int = DEFAULT_MICROBLOCK_SIZE) -> bytes:
+    """Return microblock for ``seed`` using the MiniHelix hash stream."""
+
+    output = b""
+    i = 0
+    while len(output) < block_size:
+        output += hashlib.sha256(seed + bytes([i])).digest()
+        i += 1
+    return output[:block_size]
 
 
 def find_seed(target: bytes, max_seed_len: int = 32, *, attempts: int = 1_000_000) -> bytes | None:

--- a/helix/minihelix.py
+++ b/helix/minihelix.py
@@ -29,8 +29,13 @@ def G(seed: bytes, N: int = DEFAULT_MICROBLOCK_SIZE) -> bytes:
         raise ValueError("seed must not be empty")
     if len(seed) > 255:
         raise ValueError("seed must be 255 bytes or fewer")
-    data = seed + len(seed).to_bytes(1, "big")
-    return hashlib.sha256(data).digest()[:N]
+
+    output = b""
+    i = 0
+    while len(output) < N:
+        output += hashlib.sha256(seed + bytes([i])).digest()
+        i += 1
+    return output[:N]
 
 
 def encode_header(flat_len: int, nested_len: int) -> bytes:

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -7,7 +7,7 @@ from helix import miner
 
 def test_generate_microblock():
     seed = b"abc"
-    expected = hashlib.sha256(seed + len(seed).to_bytes(4, "big")).digest()
+    expected = hashlib.sha256(seed + b"\x00").digest()[:8]
     assert miner.generate_microblock(seed) == expected
 
 

--- a/tests/test_minihelix.py
+++ b/tests/test_minihelix.py
@@ -8,7 +8,7 @@ from helix import exhaustive_miner
 def test_G_deterministic():
     seed = b"abc"
     N = 4
-    expected = hashlib.sha256(seed + len(seed).to_bytes(1, "big")).digest()[:N]
+    expected = hashlib.sha256(seed + b"\x00").digest()[:N]
     assert mh.G(seed, N) == expected
 
 


### PR DESCRIPTION
## Summary
- rework `minihelix.G` to use a hash stream
- clarify microblock generation docs
- update test for new output logic
- refactor miner microblock generation to use streamed hashing

## Testing
- `pytest -q` *(fails: create_event missing; ExhaustiveMiner signature mismatch, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6864b72f8c248329a101927c32ba5724