### PR TITLE
Implement auto-finalization logic

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -31,11 +31,207 @@ _MICROBLOCK_STORES: Dict[str, str] = {}
 
 LAST_FINALIZED_HASH = GENESIS_HASH
 LAST_FINALIZED_TIME = 0.0
+# Hash of the last finalized statement. Used to link final blocks together.
+LAST_STATEMENT_HASH = GENESIS_HASH
 
 
 def sha256(data: bytes) -> str:
     """Return hex encoded SHA-256 digest of ``data``."""
     return hashlib.sha256(data).hexdigest()
+
+
+def split_into_microblocks(
+    statement: str, microblock_size: int = DEFAULT_MICROBLOCK_SIZE
+) -> Tuple[List[bytes], int, int]:
+    """Split ``statement`` into padded microblocks."""
+
+    payload = statement.encode("utf-8")
+    orig_len = len(payload)
+    blocks: List[bytes] = []
+    for i in range(0, orig_len, microblock_size):
+        chunk = payload[i : i + microblock_size]
+        if len(chunk) < microblock_size:
+            chunk = chunk + FINAL_BLOCK_PADDING_BYTE * (microblock_size - len(chunk))
+        blocks.append(chunk)
+    return blocks, len(blocks), orig_len
+
+
+def reassemble_microblocks(blocks: List[bytes]) -> str:
+    """Return the original statement from ``blocks``."""
+
+    payload = b"".join(bytes(b) for b in blocks).rstrip(FINAL_BLOCK_PADDING_BYTE)
+    return payload.decode("utf-8")
+
+
+def create_event(
+    statement: str,
+    *,
+    microblock_size: int = DEFAULT_MICROBLOCK_SIZE,
+    parent_id: str = GENESIS_HASH,
+    private_key: str | None = None,
+    registry: Any | None = None,
+) -> Dict[str, Any]:
+    """Create a new statement event."""
+
+    if registry is not None:
+        registry.check_and_add(statement)
+
+    blocks, count, orig_len = split_into_microblocks(statement, microblock_size)
+    root, tree = _build_merkle_tree(blocks)
+
+    if private_key is None:
+        pub, priv = generate_keypair()
+    else:
+        priv = private_key
+        signing_key = signing.SigningKey(base64.b64decode(priv))
+        pub = base64.b64encode(signing_key.verify_key.encode()).decode("ascii")
+
+    signature = sign_data(statement.encode("utf-8"), priv)
+
+    header = {
+        "statement_id": sha256(statement.encode("utf-8")),
+        "original_length": orig_len,
+        "microblock_size": microblock_size,
+        "block_count": count,
+        "parent_id": parent_id,
+        "merkle_root": root.hex(),
+    }
+
+    event = {
+        "header": header,
+        "statement": statement,
+        "microblocks": blocks,
+        "merkle_tree": [[h.hex() for h in level] for level in tree],
+        "seeds": [None] * count,
+        "seed_depths": [0] * count,
+        "mined_status": [False] * count,
+        "rewards": [0.0] * count,
+        "refunds": [0.0] * count,
+        "is_closed": False,
+        "bets": {"YES": [], "NO": []},
+        "originator_pub": pub,
+        "originator_sig": signature,
+        "miners": [None] * count,
+    }
+
+    return event
+
+
+def save_event(event: Dict[str, Any], directory: str) -> str:
+    """Persist ``event`` to ``directory`` and return the file path."""
+
+    Path(directory).mkdir(parents=True, exist_ok=True)
+    evt_id = event.get("header", {}).get("statement_id")
+    if not evt_id:
+        raise ValueError("missing statement_id")
+
+    data = event.copy()
+    data["microblocks"] = [b.hex() for b in event.get("microblocks", [])]
+    if "seeds" in data:
+        data["seeds"] = [s.hex() if isinstance(s, (bytes, bytearray)) else s for s in data["seeds"]]
+
+    path = Path(directory) / f"{evt_id}.json"
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    return str(path)
+
+
+def load_event(path: str) -> Dict[str, Any]:
+    """Load and decode an event from ``path``."""
+
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    header = data.get("header", {})
+    parent = header.get("parent_id")
+    if parent and parent != GENESIS_HASH:
+        raise ValueError("invalid parent_id")
+
+    data["microblocks"] = [bytes.fromhex(b) for b in data.get("microblocks", [])]
+    seeds = []
+    for entry in data.get("seeds", []):
+        if entry is None:
+            seeds.append(None)
+        elif isinstance(entry, str):
+            seeds.append(bytes.fromhex(entry))
+        else:
+            seeds.append(entry)
+    data["seeds"] = seeds
+    return data
+
+
+def mark_mined(event: Dict[str, Any], index: int) -> None:
+    """Mark microblock ``index`` as mined and close event if complete."""
+
+    status = event.setdefault("mined_status", [False] * event["header"]["block_count"])
+    status[index] = True
+    if all(status):
+        event["is_closed"] = True
+
+
+def accept_mined_seed(
+    event: Dict[str, Any],
+    index: int,
+    encoded: bytes | List[int] | List[bytes],
+    *,
+    miner: str | None = None,
+    chain_file: str = "blockchain.jsonl",
+) -> float:
+    """Store ``encoded`` seed for ``index`` and finalize if complete."""
+
+    if isinstance(encoded, list) and encoded and isinstance(encoded[0], int):
+        encoded_bytes = bytes(encoded)
+    elif isinstance(encoded, list):
+        encoded_bytes = b"".join(bytes(e) for e in encoded)
+    else:
+        encoded_bytes = bytes(encoded)
+
+    block = event.get("microblocks", [])[index]
+    if not nested_miner.verify_nested_seed(encoded_bytes, block):
+        return 0.0
+
+    seeds = event.setdefault("seeds", [None] * event["header"]["block_count"])
+    rewards = event.setdefault("rewards", [0.0] * event["header"]["block_count"])
+    miners = event.setdefault("miners", [None] * event["header"]["block_count"])
+    seeds[index] = encoded_bytes
+    miners[index] = miner
+    rewards[index] = compute_reward(encoded_bytes, event["header"].get("microblock_size", DEFAULT_MICROBLOCK_SIZE))
+    mark_mined(event, index)
+
+    if event.get("is_closed") and all(event.get("mined_status", [])) and not event.get("finalized"):
+        finalize_event(event, node_id=miner, chain_file=chain_file)
+
+    return 0.0
+
+
+def verify_event_signature(event: Dict[str, Any]) -> bool:
+    """Return ``True`` if the event originator signature is valid."""
+
+    statement = event.get("statement", "")
+    pub = event.get("originator_pub")
+    sig = event.get("originator_sig")
+    if not statement or not pub or not sig:
+        return False
+    return verify_signature(statement.encode("utf-8"), sig, pub)
+
+
+def verify_seed_chain(encoded: bytes, block: bytes) -> bool:
+    """Wrapper around :func:`nested_miner.verify_nested_seed`."""
+
+    return nested_miner.verify_nested_seed(encoded, block)
+
+
+def verify_statement(event: Dict[str, Any]) -> bool:
+    """Return ``True`` if all seeds regenerate their microblocks."""
+
+    blocks = event.get("microblocks", [])
+    seeds = event.get("seeds", [])
+    for block, seed in zip(blocks, seeds):
+        if seed is None:
+            return False
+        if not nested_miner.verify_nested_seed(seed, block):
+            return False
+    return True
 
 # ... all other functions from your provided code continue unmodified ...
 
@@ -89,7 +285,7 @@ def finalize_event(
     penalty is performed by :class:`helix.helix_node.HelixNode`.
     """
 
-    global LAST_FINALIZED_HASH, LAST_FINALIZED_TIME
+    global LAST_FINALIZED_HASH, LAST_FINALIZED_TIME, LAST_STATEMENT_HASH
 
     if not event.get("is_closed"):
         raise ValueError("event must be closed before finalization")
@@ -104,10 +300,15 @@ def finalize_event(
     prev_block = chain[-1] if chain else None
     bonus_receiver = prev_block.get("finalizer") if prev_block else None
 
+    # Reassemble statement and compute its hash
+    statement = reassemble_microblocks(event.get("microblocks", []))
+    statement_id = sha256(statement.encode("utf-8"))
+
     # Build the new block header
     header = {
         "parent_id": LAST_FINALIZED_HASH,
-        "event_id": event.get("header", {}).get("statement_id"),
+        "event_id": statement_id,
+        "previous_hash": LAST_STATEMENT_HASH,
         "timestamp": datetime.utcfromtimestamp(now).isoformat(),
         "finalizer": node_id,
         "delta_seconds": delta_seconds,
@@ -122,12 +323,16 @@ def finalize_event(
     # Persist block and update globals
     _bc.append_block(header, path=str(chain_file))
     LAST_FINALIZED_HASH = block_id
+    LAST_STATEMENT_HASH = statement_id
 
     # Store metadata in the event
-    event.setdefault("header", {})["delta_seconds"] = delta_seconds
-    event["header"]["delta_bonus"] = bool(delta_bonus)
+    header_data = event.setdefault("header", {})
+    header_data["delta_seconds"] = delta_seconds
+    header_data["delta_bonus"] = bool(delta_bonus)
+    header_data["statement_id"] = statement_id
     event["finalized"] = True
     event["block_header"] = header
+    event["statement"] = statement
 
     # Payouts and balances are intentionally simplified. The original project
     # applied compression rewards and bet payouts which are out of scope here.


### PR DESCRIPTION
## Summary
- add microblock utilities and event creation helpers
- finalize events automatically when the last microblock is mined
- track last statement hash and include `previous_hash` in block header
- trim padding when reassembling microblocks

## Testing
- `./run_tests.sh` *(fails: AttributeError and TypeError in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_6864c5651d308329b24ddac532808bec