### PR TITLE
Add finalized block logging

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -44,6 +44,8 @@ event_metadata: Dict[str, Dict[str, int]] = {}
 
 # File used to persist finalized statements
 FINALIZED_FILE = Path("finalized_statements.jsonl")
+# File used to log finalized block summaries
+FINALIZED_EVENT_LOG = Path("finalized_log.jsonl")
 
 
 def sha256(data: bytes) -> str:
@@ -382,6 +384,23 @@ def _legacy_finalize_event(
 
     event["payouts"] = payouts
     event["miner_reward"] = miner_reward
+
+    # Append summary entry for this finalized block
+    try:
+        with open(FINALIZED_EVENT_LOG, "a", encoding="utf-8") as fh:
+            json.dump(
+                {
+                    "block_id": block_id,
+                    "statement_id": statement_id,
+                    "miner_id": node_id,
+                    "delta_seconds": delta_seconds,
+                    "compression_reward": miner_reward,
+                },
+                fh,
+            )
+            fh.write("\n")
+    except Exception as exc:  # pragma: no cover - logging only
+        print(f"Failed to record finalized event log: {exc}")
 
     # Persist event if requested
     if events_dir:

--- a/helix/ledger.py
+++ b/helix/ledger.py
@@ -1,3 +1,6 @@
+from typing import Any, Dict
+
+
 def apply_mining_results(
     event: Dict[str, Any],
     balances: Dict[str, float],

--- a/helix/minihelix.py
+++ b/helix/minihelix.py
@@ -1,12 +1,41 @@
 import hashlib
 import os
 import random
+from typing import Optional
 
-from .minihelix import DEFAULT_MICROBLOCK_SIZE, G
+DEFAULT_MICROBLOCK_SIZE = 8
+
+
+def G(seed: bytes, N: int = DEFAULT_MICROBLOCK_SIZE) -> bytes:
+    """Return the first ``N`` bytes of the MiniHelix hash stream for ``seed``."""
+    output = hashlib.sha256(seed).digest()
+    while len(output) < N:
+        output += hashlib.sha256(output).digest()
+    return output[:N]
+
+
+def mine_seed(target: bytes, max_attempts: int = 100000) -> Optional[bytes]:
+    """Brute-force a seed producing ``target`` using :func:`G`."""
+    N = len(target)
+    for length in range(1, N + 1):
+        max_value = min(256 ** length, max_attempts)
+        for i in range(max_value):
+            seed = i.to_bytes(length, "big")
+            if G(seed, N) == target:
+                return seed
+        max_attempts -= max_value
+        if max_attempts <= 0:
+            break
+    return None
+
+
+def verify_seed(seed: bytes, target: bytes) -> bool:
+    """Return ``True`` if ``seed`` regenerates ``target``."""
+    return G(seed, len(target)) == target
 
 
 def truncate_hash(data: bytes, length: int) -> bytes:
-    """Return the first `length` bytes of SHA256(data)."""
+    """Return the first ``length`` bytes of SHA256 of ``data``."""
     return hashlib.sha256(data).digest()[:length]
 
 
@@ -21,8 +50,8 @@ def generate_microblock(seed: bytes, block_size: int = DEFAULT_MICROBLOCK_SIZE) 
     return output[:block_size]
 
 
-def find_seed(target: bytes, max_seed_len: int = 32, *, attempts: int = 1_000_000) -> bytes | None:
-    """Search for a seed that generates `target` when truncated to len(target)."""
+def find_seed(target: bytes, max_seed_len: int = 32, *, attempts: int = 1_000_000) -> Optional[bytes]:
+    """Randomly search for a seed that generates ``target``."""
     target_len = len(target)
     for _ in range(attempts):
         seed_len = random.randint(1, max_seed_len)
@@ -34,6 +63,10 @@ def find_seed(target: bytes, max_seed_len: int = 32, *, attempts: int = 1_000_00
 
 
 __all__ = [
+    "DEFAULT_MICROBLOCK_SIZE",
+    "G",
+    "mine_seed",
+    "verify_seed",
     "truncate_hash",
     "generate_microblock",
     "find_seed",

--- a/tests/test_finalized_log.py
+++ b/tests/test_finalized_log.py
@@ -1,0 +1,30 @@
+import json
+import pytest
+
+pytest.importorskip("nacl")
+
+from helix import event_manager as em
+
+
+@pytest.fixture(autouse=True)
+def _mock_verify(monkeypatch):
+    monkeypatch.setattr(em.nested_miner, "verify_nested_seed", lambda c, b: True)
+
+
+def test_finalized_log_written(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    event = em.create_event("log", microblock_size=5)
+    for idx in range(event["header"]["block_count"]):
+        em.accept_mined_seed(event, idx, bytes([1, 1]) + b"a", miner="MINER")
+
+    assert event.get("finalized")
+
+    log_file = tmp_path / "finalized_log.jsonl"
+    assert log_file.exists()
+
+    entry = json.loads(log_file.read_text().splitlines()[-1])
+    assert entry["block_id"] == event["block_header"]["block_id"]
+    assert entry["statement_id"] == event["header"]["statement_id"]
+    assert entry["miner_id"] == "MINER"
+    assert entry["delta_seconds"] == event["block_header"]["delta_seconds"]
+    assert entry["compression_reward"] == event["miner_reward"]


### PR DESCRIPTION
## Summary
- log finalized block information to `finalized_log.jsonl`
- implement minimal minihelix utilities so tests run
- fix missing typing imports in `ledger`
- test finalized log output

## Testing
- `pytest tests/test_finalized_log.py -q`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864d2aa7eb48329a8bc3676b663c174