### PR TITLE
Implement basic replay_and_remine helper

### DIFF
--- a/helix/event_manager.py
+++ b/helix/event_manager.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 import os
 import tempfile
+import logging
 
 from datetime import datetime
 from nacl import signing
@@ -14,7 +15,7 @@ from .config import GENESIS_HASH
 from .signature_utils import verify_signature, sign_data, generate_keypair
 import time
 from .merkle_utils import build_merkle_tree as _build_merkle_tree
-from . import nested_miner, betting_interface
+from . import nested_miner, betting_interface, exhaustive_miner
 from .betting_interface import get_bets_for_event
 from .ledger import apply_mining_results
 from .statement_registry import finalize_statement
@@ -476,4 +477,66 @@ def finalize_event(
 
     _finalize_event_by_id(str(event))
     return None
+
+
+def replay_and_remine(statement_id: str) -> None:
+    """Re-mine microblocks for ``statement_id`` from their output.
+
+    Loads ``data/events/<id>.json`` and attempts to compress each microblock
+    again using :func:`exhaustive_miner.exhaustive_mine`.  The number of blocks
+    that yield a smaller encoded seed is logged.  This is a scaffold and does
+    not persist any new seeds.
+    """
+
+    path = Path("data/events") / f"{statement_id}.json"
+    if not path.exists():
+        raise FileNotFoundError(str(path))
+
+    event = load_event(str(path))
+
+    blocks = event.get("microblocks", [])
+    seeds = event.get("seeds", [None] * len(blocks))
+
+    def _seed_len(seed: Any) -> int:
+        if seed is None:
+            return math.inf
+        if isinstance(seed, bytes):
+            return len(seed)
+        if isinstance(seed, str):
+            return len(bytes.fromhex(seed))
+        if isinstance(seed, list):
+            if seed and isinstance(seed[0], int):
+                return len(bytes(seed))
+            total = 0
+            for part in seed:
+                if isinstance(part, str):
+                    total += len(bytes.fromhex(part))
+                elif isinstance(part, list) and part and isinstance(part[0], int):
+                    total += len(bytes(part))
+                else:
+                    total += len(part)
+            return total
+        return len(seed)
+
+    improved = 0
+    for idx, block in enumerate(blocks):
+        chain = exhaustive_miner.exhaustive_mine(block, max_depth=5)
+        if chain is None:
+            continue
+        encoded = bytes([len(chain), len(chain[0])]) + b"".join(chain)
+        cur_len = _seed_len(seeds[idx])
+        if len(encoded) < cur_len:
+            improved += 1
+        logging.debug(
+            "microblock %d old_len=%s new_len=%d",
+            idx,
+            "inf" if cur_len == math.inf else int(cur_len),
+            len(encoded),
+        )
+
+    logging.info(
+        "%d/%d microblocks can be recompressed further",
+        improved,
+        len(blocks),
+    )
 

--- a/helix/ledger.py
+++ b/helix/ledger.py
@@ -1,3 +1,6 @@
+from typing import Any, Dict
+
+
 def apply_mining_results(
     event: Dict[str, Any],
     balances: Dict[str, float],

--- a/helix/minihelix.py
+++ b/helix/minihelix.py
@@ -2,7 +2,18 @@ import hashlib
 import os
 import random
 
-from .minihelix import DEFAULT_MICROBLOCK_SIZE, G
+DEFAULT_MICROBLOCK_SIZE = 8
+
+
+def G(seed: bytes, N: int = DEFAULT_MICROBLOCK_SIZE) -> bytes:
+    """Return ``N`` bytes generated from ``seed`` using MiniHelix."""
+
+    output = b""
+    current = hashlib.sha256(seed).digest()
+    while len(output) < N:
+        output += current
+        current = hashlib.sha256(current).digest()
+    return output[:N]
 
 
 def truncate_hash(data: bytes, length: int) -> bytes:
@@ -33,8 +44,15 @@ def find_seed(target: bytes, max_seed_len: int = 32, *, attempts: int = 1_000_00
     return None
 
 
+def mine_seed(target_block: bytes, max_attempts: int | None = 1_000_000) -> bytes | None:
+    """Compatibility wrapper calling :func:`find_seed`."""
+
+    return find_seed(target_block, max_seed_len=DEFAULT_MICROBLOCK_SIZE, attempts=max_attempts or 0)
+
+
 __all__ = [
     "truncate_hash",
     "generate_microblock",
     "find_seed",
+    "mine_seed",
 ]


### PR DESCRIPTION
## Summary
- scaffold a `replay_and_remine()` helper in `event_manager`
- provide a minimal fallback `minihelix` module with defaults
- fix ledger import for typing

## Testing
- `./run_tests.sh` *(fails: ImportError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864d2c931f48329b15077c577e481eb