### PR TITLE
Add chain replay test with minihelix fallbacks

### DIFF
--- a/helix/ledger.py
+++ b/helix/ledger.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def apply_mining_results(
     event: Dict[str, Any],
     balances: Dict[str, float],

--- a/helix/minihelix.py
+++ b/helix/minihelix.py
@@ -1,8 +1,53 @@
+"""Pure Python fallback for the MiniHelix hash functions."""
+
 import hashlib
 import os
 import random
 
-from .minihelix import DEFAULT_MICROBLOCK_SIZE, G
+try:  # pragma: no cover - optional native extension
+    from .minihelix import DEFAULT_MICROBLOCK_SIZE, HEADER_SIZE, G
+    from .minihelix import mine_seed, verify_seed, decode_header, unpack_seed
+except Exception:  # pragma: no cover - use slow Python implementations
+    DEFAULT_MICROBLOCK_SIZE = 8
+    HEADER_SIZE = 2
+
+    def G(seed: bytes, N: int = DEFAULT_MICROBLOCK_SIZE) -> bytes:
+        """Return ``N`` bytes of MiniHelix output for ``seed``."""
+        output = b""
+        current = hashlib.sha256(seed).digest()
+        output += current
+        while len(output) < N:
+            current = hashlib.sha256(current).digest()
+            output += current
+        return output[:N]
+
+    def mine_seed(target: bytes, *, max_attempts: int | None = None) -> bytes | None:
+        """Brute force a seed generating ``target``."""
+        attempts = 0
+        N = len(target)
+        while max_attempts is None or attempts < max_attempts:
+            seed = os.urandom(1)
+            if G(seed, N) == target:
+                return seed
+            attempts += 1
+        return None
+
+    def verify_seed(seed: bytes, target: bytes) -> bool:
+        return G(seed, len(target)) == target
+
+    def decode_header(hdr: bytes) -> tuple[int, int]:
+        if len(hdr) != HEADER_SIZE:
+            raise ValueError("invalid header")
+        return hdr[0], hdr[1]
+
+    def unpack_seed(seed: bytes, block_size: int) -> bytes:
+        depth = seed[0]
+        length = seed[1]
+        payload = seed[2:2 + length]
+        current = payload
+        for _ in range(depth - 1):
+            current = G(current, block_size)
+        return current
 
 
 def truncate_hash(data: bytes, length: int) -> bytes:
@@ -37,4 +82,9 @@ __all__ = [
     "truncate_hash",
     "generate_microblock",
     "find_seed",
+    "G",
+    "mine_seed",
+    "verify_seed",
+    "decode_header",
+    "unpack_seed",
 ]

--- a/tests/test_chain_replay.py
+++ b/tests/test_chain_replay.py
@@ -1,0 +1,40 @@
+import hashlib
+from pathlib import Path
+import pytest
+
+import blockchain as bc
+from helix import event_manager
+
+
+def _find_event_file(evt_id: str) -> Path | None:
+    for directory in (Path("data/events"), Path("events")):
+        path = directory / f"{evt_id}.json"
+        if path.exists():
+            return path
+    return None
+
+
+def test_chain_replay():
+    chain_path = Path("blockchain.jsonl")
+    if not chain_path.exists():
+        pytest.skip("blockchain.jsonl not available")
+
+    chain = bc.load_chain(str(chain_path))
+    for block in chain:
+        delta = block.get("delta_seconds", 0)
+        assert delta >= 0
+        assert delta < 256
+
+        event_ids = block.get("event_ids") or block.get("event_id") or []
+        if isinstance(event_ids, str):
+            event_ids = [event_ids]
+
+        for evt_id in event_ids:
+            evt_file = _find_event_file(evt_id)
+            if not evt_file:
+                pytest.skip(f"missing event file for {evt_id}")
+            event = event_manager.load_event(str(evt_file))
+            statement = event_manager.reassemble_microblocks(event["microblocks"])
+            digest = hashlib.sha256(statement.encode("utf-8")).hexdigest()
+            assert digest == evt_id
+            assert digest == event["header"]["statement_id"]


### PR DESCRIPTION
## Summary
- implement pure Python fallback in `helix/minihelix.py` so that importing the
  module works without the native extension
- fix `helix/ledger.py` import error by enabling postponed evaluation of type
  hints
- add `tests/test_chain_replay.py` to verify statement hashes and delta seconds

## Testing
- `pytest tests/test_chain_replay.py -q`
- `pytest -q` *(fails: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6864d2e946748329979c36af1b17b555