### PR TITLE
Add compression ratio utility function

### DIFF
--- a/helix/utils/__init__.py
+++ b/helix/utils/__init__.py
@@ -1,0 +1,5 @@
+from .metrics import compression_ratio
+
+__all__ = [
+    "compression_ratio",
+]

--- a/helix/utils/metrics.py
+++ b/helix/utils/metrics.py
@@ -1,0 +1,4 @@
+def compression_ratio(event: dict) -> float:
+    original = event["header"]["microblock_size"] * len(event["seeds"])
+    compressed = sum(len(s) for s in event["seeds"] if s)
+    return round(1.0 - compressed / original, 4)


### PR DESCRIPTION
## Summary
- implement `compression_ratio` to calculate microblock compression savings
- expose `compression_ratio` from `helix.utils`

## Testing
- `./run_tests.sh` *(fails: ImportError while loading conftest)*

------
https://chatgpt.com/codex/tasks/task_e_6864d2f917ec8329b448cae70b520609