### PR TITLE
Add finalized statement listing utility

### DIFF
--- a/helix/ledger.py
+++ b/helix/ledger.py
@@ -1,3 +1,134 @@
+import json
+import os
+import time
+from typing import Any, Dict, Tuple
+
+from . import event_manager
+
+_BLOCK_HEADERS: Dict[str, Dict[str, Any]] = {}
+_PENDING_BONUS: Dict[str, str] = {}
+_VERIFICATION_QUEUE: list[tuple[Dict[str, Any] | None, bool, str]] = []
+_BONUS_AMOUNT = 2.0
+
+
+def delta_claim_valid(current: Dict[str, Any], parent: Dict[str, Any]) -> bool:
+    """Placeholder delta claim validation used in tests."""
+    return True
+
+
+def get_total_supply(path: str = "supply.json") -> float:
+    """Return the recorded total HLX supply."""
+    if not os.path.exists(path):
+        return 0.0
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return float(json.load(fh).get("total", 0.0))
+    except Exception:
+        return 0.0
+
+def load_balances(path: str) -> Dict[str, float]:
+    """Return balances mapping from ``path`` if it exists."""
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict):
+            return {str(k): float(v) for k, v in data.items()}
+    except Exception:
+        pass
+    return {}
+
+
+def save_balances(balances: Dict[str, float], path: str) -> None:
+    """Persist ``balances`` to ``path``."""
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(balances, fh, indent=2)
+
+
+def log_ledger_event(
+    action: str,
+    wallet: str,
+    amount: float,
+    reason: str,
+    block_hash: str,
+    *,
+    journal_file: str = "ledger_journal.jsonl",
+) -> None:
+    entry = {
+        "action": action,
+        "wallet": wallet,
+        "amount": amount,
+        "reason": reason,
+        "block": block_hash,
+        "timestamp": int(time.time()),
+    }
+    with open(journal_file, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
+def _update_total_supply(delta: float, *, path: str = "supply.json") -> None:
+    total = 0.0
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                total = float(json.load(fh).get("total", 0.0))
+        except Exception:
+            total = 0.0
+    total += delta
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump({"total": total}, fh)
+
+
+def apply_delta_bonus(
+    wallet: str,
+    balances: Dict[str, float],
+    amount: float,
+    *,
+    block_hash: str = "",
+    journal_file: str = "ledger_journal.jsonl",
+) -> None:
+    balances[wallet] = balances.get(wallet, 0.0) + amount
+    log_ledger_event("mint", wallet, amount, "delta_bonus", block_hash, journal_file=journal_file)
+
+
+def apply_delta_penalty(
+    wallet: str,
+    balances: Dict[str, float],
+    amount: float,
+    *,
+    block_hash: str = "",
+    journal_file: str = "ledger_journal.jsonl",
+) -> None:
+    balances[wallet] = balances.get(wallet, 0.0) - amount
+    log_ledger_event("burn", wallet, amount, "delta_penalty", block_hash, journal_file=journal_file)
+
+
+def compression_stats(events_dir: str) -> Tuple[int, float]:
+    """Return total bytes saved and HLX minted for events in ``events_dir``."""
+    total_saved = 0
+    total_hlx = 0.0
+    if not os.path.isdir(events_dir):
+        return total_saved, total_hlx
+
+    for path in os.listdir(events_dir):
+        if not path.endswith(".json"):
+            continue
+        evt = event_manager.load_event(os.path.join(events_dir, path))
+        seeds = evt.get("seeds", [])
+        microblocks = evt.get("microblocks", [])
+        rewards = evt.get("rewards", [])
+        refunds = evt.get("refunds", [])
+        total_hlx += sum(rewards) - sum(refunds)
+        for blk, seed in zip(microblocks, seeds):
+            if seed is None:
+                continue
+            blk_bytes = bytes.fromhex(blk) if isinstance(blk, str) else blk
+            seed_bytes = bytes(seed) if isinstance(seed, list) else seed
+            total_saved += max(0, len(blk_bytes) - len(seed_bytes))
+    return total_saved, total_hlx
+
+
 def apply_mining_results(
     event: Dict[str, Any],
     balances: Dict[str, float],
@@ -116,3 +247,16 @@ def apply_mining_results(
             _VERIFICATION_QUEUE.append((prev_hdr, bool(prev_hdr), block_id))
             if current_finalizer:
                 _PENDING_BONUS[block_id] = current_finalizer
+
+
+__all__ = [
+    "load_balances",
+    "save_balances",
+    "log_ledger_event",
+    "apply_delta_bonus",
+    "apply_delta_penalty",
+    "apply_mining_results",
+    "compression_stats",
+    "get_total_supply",
+    "_update_total_supply",
+]

--- a/tests/test_list_finalized_statements.py
+++ b/tests/test_list_finalized_statements.py
@@ -1,0 +1,24 @@
+import json
+import pytest
+
+from helix import statement_registry as sr
+
+
+def test_list_finalized_statements(tmp_path, monkeypatch):
+    path = tmp_path / "finalized_statements.jsonl"
+    entries = [
+        {"statement_id": "a", "timestamp": 1.0, "delta_seconds": 0.1, "seeds": ["aa"]},
+        {"statement_id": "b", "timestamp": 2.0, "delta_seconds": 0.2, "seeds": ["bb", "01"]},
+        {"statement_id": "c", "timestamp": 3.0, "delta_seconds": 0.3, "seeds": ["cc"]},
+    ]
+    with open(path, "w", encoding="utf-8") as fh:
+        for e in entries:
+            fh.write(json.dumps(e) + "\n")
+
+    monkeypatch.setattr(sr, "_FINALIZED_FILE", str(path))
+
+    result = sr.list_finalized_statements(limit=2)
+    assert result == [
+        ("c", 3.0, 0.3, 1),
+        ("b", 2.0, 0.2, 2),
+    ]


### PR DESCRIPTION
## Summary
- introduce `list_finalized_statements` helper to inspect recent finalized statements
- implement minimal pure Python minihelix and ledger modules
- add test coverage for finalized statement listing

## Testing
- `./run_tests.sh` *(fails: 16 failed, 56 passed, 31 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6864d2de51488329aba3dfc54ed32bab