### PR TITLE
Add basic React dashboard

### DIFF
--- a/dashboard/frontend/package.json
+++ b/dashboard/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "helix-dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.4.0",
+    "axios": "^1.4.0"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.3.2"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/dashboard/frontend/src/App.js
+++ b/dashboard/frontend/src/App.js
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+import { BrowserRouter as Router, Routes, Route, Link, useParams } from 'react-router-dom';
+import axios from 'axios';
+import './index.css';
+
+const Navbar = () => (
+  <nav className="bg-gray-800 p-4 text-white flex space-x-4">
+    <Link to="/" className="hover:underline">Home</Link>
+    <Link to="/wallet/1" className="hover:underline">Wallet</Link>
+  </nav>
+);
+
+const Home = () => {
+  const [statements, setStatements] = useState([]);
+
+  useEffect(() => {
+    axios.get('http://localhost:8000/api/statements?limit=10')
+      .then(res => setStatements(res.data))
+      .catch(err => console.error(err));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Latest Statements</h1>
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead>
+          <tr>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Compression %</th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Delta Seconds</th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Timestamp</th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {statements.map(st => (
+            <tr key={st.statement_id} className="hover:bg-gray-100">
+              <td className="px-6 py-4 whitespace-nowrap">
+                <Link to={`/statement/${st.statement_id}`} className="text-indigo-600 hover:underline">
+                  {st.statement_id}
+                </Link>
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap">{st.compression_percent}</td>
+              <td className="px-6 py-4 whitespace-nowrap">{st.delta_seconds}</td>
+              <td className="px-6 py-4 whitespace-nowrap">{st.timestamp}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+const Statement = () => {
+  const { id } = useParams();
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    axios.get(`/api/statement/${id}`)
+      .then(res => setData(res.data))
+      .catch(err => console.error(err));
+  }, [id]);
+
+  if (!data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Statement {id}</h1>
+      <div>Original Size: {data.original_size}</div>
+      <div>Compressed Size: {data.compressed_size}</div>
+      <pre className="bg-gray-100 p-2 whitespace-pre-wrap">{data.reconstructed}</pre>
+      <div>
+        <h2 className="text-xl font-semibold">Miners</h2>
+        <ul className="list-disc pl-5">
+          {data.miners && data.miners.map((miner, idx) => (
+            <li key={idx}>{miner} - Seed Length: {data.seed_lengths[idx]}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+const Wallet = () => {
+  const { walletId } = useParams();
+  const [balance, setBalance] = useState(null);
+
+  useEffect(() => {
+    axios.get(`/api/balance/${walletId}`)
+      .then(res => setBalance(res.data.balance))
+      .catch(err => console.error(err));
+  }, [walletId]);
+
+  if (balance === null) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Wallet {walletId}</h1>
+      <div className="mt-2">HLX Balance: {balance}</div>
+    </div>
+  );
+};
+
+const App = () => (
+  <Router>
+    <Navbar />
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/statement/:id" element={<Statement />} />
+      <Route path="/wallet/:walletId" element={<Wallet />} />
+    </Routes>
+  </Router>
+);
+
+export default App;

--- a/dashboard/frontend/src/index.css
+++ b/dashboard/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/dashboard/frontend/src/index.js
+++ b/dashboard/frontend/src/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.getElementById('root')
+);

--- a/dashboard/frontend/tailwind.config.js
+++ b/dashboard/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add React app skeleton in `dashboard/frontend`
- implement routing for home, statement, and wallet pages
- show statements list, statement details, and wallet balance
- configure Tailwind and dependencies

## Testing
- `./run_tests.sh` *(fails: ImportError due to helix.minihelix circular import)*

------
https://chatgpt.com/codex/tasks/task_e_6864d457eb008329873fef2f71412ba1