### PR TITLE
Add submit statement API endpoint

### DIFF
--- a/dashboard/backend/main.py
+++ b/dashboard/backend/main.py
@@ -4,16 +4,27 @@ import json
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 
 try:
     from helix.ledger import load_balances, get_total_supply
 except Exception:  # pragma: no cover - optional fallback
     from ledger import load_balances, get_total_supply  # type: ignore
 
+try:
+    from helix.event_manager import submit_statement
+except Exception:  # pragma: no cover - optional fallback
+    from event_manager import submit_statement  # type: ignore
+
 app = FastAPI()
 
 EVENTS_DIR = Path("data/events")
 FINALIZED_FILE = Path("finalized_statements.jsonl")
+
+
+class SubmitRequest(BaseModel):
+    statement: str
+    wallet_id: str
 
 
 @app.get("/api/statements")
@@ -50,6 +61,16 @@ async def get_statement(statement_id: str) -> dict:
         return json.loads(path.read_text())
     except Exception as exc:  # pragma: no cover - invalid file
         raise HTTPException(status_code=500, detail=str(exc))
+
+
+@app.post("/api/submit")
+async def submit_statement_api(req: SubmitRequest) -> dict:
+    """Create a new statement event and return its ID."""
+    try:
+        event_id = submit_statement(req.statement, req.wallet_id)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"ok": True, "message": "Statement submitted", "event_id": event_id}
 
 
 @app.get("/api/balance/{wallet_id}")


### PR DESCRIPTION
## Summary
- expose new `POST /api/submit` endpoint in dashboard backend
- implement `submit_statement` helper in event manager
- use wallet file to sign submitted statements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nacl')*

------
https://chatgpt.com/codex/tasks/task_e_6864d82ae1f08329bc4b246d46202ba3