### PR TITLE
Add events list UI and API

### DIFF
--- a/dashboard/backend/main.py
+++ b/dashboard/backend/main.py
@@ -7,8 +7,12 @@ from fastapi import FastAPI, HTTPException
 
 try:
     from helix.ledger import load_balances, get_total_supply
+    from helix.event_manager import load_event
+    from helix.utils import compression_ratio
 except Exception:  # pragma: no cover - optional fallback
     from ledger import load_balances, get_total_supply  # type: ignore
+    from event_manager import load_event  # type: ignore
+    from utils.metrics import compression_ratio  # type: ignore
 
 app = FastAPI()
 
@@ -38,6 +42,32 @@ async def list_statements() -> list[dict]:
             }
         )
     return statements
+
+
+@app.get("/api/events")
+async def list_events() -> list[dict]:
+    """Return all finalized events."""
+    if not EVENTS_DIR.exists():
+        return []
+
+    events: list[dict] = []
+    for path in sorted(EVENTS_DIR.glob("*.json")):
+        try:
+            event = load_event(str(path))
+        except Exception:
+            continue
+        if not event.get("is_closed") and not event.get("finalized"):
+            continue
+        header = event.get("header", {})
+        evt_id = header.get("statement_id", path.stem)
+        events.append(
+            {
+                "id": evt_id,
+                "statement": event.get("statement"),
+                "compression": compression_ratio(event),
+            }
+        )
+    return events
 
 
 @app.get("/api/statement/{statement_id}")

--- a/dashboard/frontend/src/App.js
+++ b/dashboard/frontend/src/App.js
@@ -2,10 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link, useParams } from 'react-router-dom';
 import axios from 'axios';
 import './index.css';
+import EventList from './components/EventList';
 
 const Navbar = () => (
   <nav className="bg-gray-800 p-4 text-white flex space-x-4">
     <Link to="/" className="hover:underline">Home</Link>
+    <Link to="/events" className="hover:underline">Events</Link>
     <Link to="/wallet/1" className="hover:underline">Wallet</Link>
   </nav>
 );
@@ -105,6 +107,7 @@ const App = () => (
     <Navbar />
     <Routes>
       <Route path="/" element={<Home />} />
+      <Route path="/events" element={<EventList />} />
       <Route path="/statement/:id" element={<Statement />} />
       <Route path="/wallet/:walletId" element={<Wallet />} />
     </Routes>

--- a/dashboard/frontend/src/components/EventList.js
+++ b/dashboard/frontend/src/components/EventList.js
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+
+export default function EventList() {
+  const [events, setEvents] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/events')
+      .then(res => res.json())
+      .then(setEvents)
+      .catch(err => console.error("Failed to load events", err));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-bold mb-4">Finalized Events</h2>
+      <ul className="space-y-2">
+        {events.map(ev => (
+          <li key={ev.id} className="p-4 bg-gray-100 rounded shadow">
+            <p><strong>ID:</strong> {ev.id}</p>
+            <p><strong>Statement:</strong> {ev.statement}</p>
+            <p><strong>Compression:</strong> {ev.compression * 100}%</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new EventList component to show finalized events
- expose `/api/events` endpoint in backend
- link Events page in frontend router and navbar

## Testing
- `pip install PyNaCl`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nacl' during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6864d963399083299f2a9400a65e911c