### PR TITLE
Add Windows launch script

### DIFF
--- a/launch_helix_gui.bat
+++ b/launch_helix_gui.bat
@@ -1,0 +1,8 @@
+@echo off
+echo Starting Helix Backend...
+start cmd /k "cd /d C:\Users\Robin\helix && uvicorn dashboard.backend.main:app --reload --port 8000"
+
+echo Starting Helix Frontend...
+start cmd /k "cd /d C:\Users\Robin\helix\dashboard\frontend && npm start"
+
+exit


### PR DESCRIPTION
## Summary
- add a `.bat` script to start backend and frontend in separate cmd windows

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'nacl')*

------
https://chatgpt.com/codex/tasks/task_e_6864db8ba38c8329bac250a64be8f015