### PR TITLE
Fix GUI launcher paths

### DIFF
--- a/launch_helix_gui.bat
+++ b/launch_helix_gui.bat
@@ -1,8 +1,6 @@
 @echo off
 echo Starting Helix Backend...
-start cmd /k "cd /d C:\Users\Robin\helix && uvicorn dashboard.backend.main:app --reload --port 8000"
-
+start cmd /k "cd /d C:\Users\93rob\OneDrive\Documents\GitHub\helix-protocol && uvicorn dashboard.backend.main:app --reload --port 8000"
 echo Starting Helix Frontend...
-start cmd /k "cd /d C:\Users\Robin\helix\dashboard\frontend && npm start"
-
+start cmd /k "cd /d C:\Users\93rob\OneDrive\Documents\GitHub\helix-protocol\dashboard\frontend && npm start"
 exit


### PR DESCRIPTION
## Summary
- remove old command references in `launch_helix_gui.bat`

## Testing
- `pip install -r requirements.txt`
- `./run_tests.sh` *(fails: cannot import name 'load_event' from helix.event_manager)*


------
https://chatgpt.com/codex/tasks/task_e_6864df0b04108329b00d83b53734200c