### PR TITLE
Update Helix GUI launcher batch script

### DIFF
--- a/launch_helix_gui.bat
+++ b/launch_helix_gui.bat
@@ -1,6 +1,10 @@
 @echo off
-echo Starting Helix Backend...
-start cmd /k "cd /d C:\Users\93rob\OneDrive\Documents\GitHub\helix-protocol && uvicorn dashboard.backend.main:app --reload --port 8000"
-echo Starting Helix Frontend...
-start cmd /k "cd /d C:\Users\93rob\OneDrive\Documents\GitHub\helix-protocol\dashboard\frontend && npm start"
+set PYTHONPATH=%CD%
+
+echo [ Helix Backend Launching... ]
+start cmd /k "cd /d %CD% && uvicorn dashboard.backend.main:app --reload || %APPDATA%\Python\Python313\Scripts\uvicorn.exe dashboard.backend.main:app --reload"
+
+echo [ Helix Frontend Launching... ]
+start cmd /k "cd /d %CD%\dashboard\frontend && npm install && npm start"
+
 exit


### PR DESCRIPTION
## Summary
- update `launch_helix_gui.bat` to set `PYTHONPATH`
- run backend and frontend in new persistent terminal windows
- add fallback `uvicorn` command and installation step for frontend

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'nacl')*

------
https://chatgpt.com/codex/tasks/task_e_68652de5734883299170ed3009a469dc