### PR TITLE
Add active statements API

### DIFF
--- a/dashboard/backend/main.py
+++ b/dashboard/backend/main.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import json
+import base64
+import os
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from helix import signature_utils
@@ -26,6 +29,12 @@ except Exception:  # pragma: no cover - optional fallback
     from event_manager import submit_statement as submit_event_statement  # type: ignore
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 EVENTS_DIR = Path("data/events")
 FINALIZED_FILE = Path("finalized_statements.jsonl")
@@ -59,6 +68,59 @@ async def list_statements(limit: int = 10) -> list[dict]:
             }
         )
     return statements
+
+
+@app.get("/api/statements/active_status")
+async def active_status() -> list[dict]:
+    """Return details for all unfinalized statements."""
+    if not EVENTS_DIR.exists():
+        return []
+
+    entries: list[tuple[float, dict]] = []
+    for path in EVENTS_DIR.glob("*.json"):
+        try:
+            event = load_event(str(path))
+        except Exception:
+            continue
+        if event.get("finalized"):
+            continue
+        header = event.get("header", {})
+        microblock_size = int(header.get("microblock_size", 0))
+        block_count = int(header.get("block_count", 0))
+        seeds = event.get("seeds", [None] * block_count)
+        mined_blocks = []
+        for idx, seed in enumerate(seeds):
+            if not seed:
+                continue
+            if isinstance(seed, list):
+                seed_bytes = bytes(seed)
+                seed_hex = seed_bytes.hex()
+            elif isinstance(seed, str):
+                seed_hex = seed
+            else:
+                seed_hex = bytes(seed).hex()
+            mined_blocks.append({"index": idx, "seed": seed_hex})
+        unmined_blocks = [idx for idx, seed in enumerate(seeds) if not seed]
+        header_b64 = base64.b64encode(json.dumps(header).encode("utf-8")).decode(
+            "ascii"
+        )
+        submitted_at = int(os.path.getmtime(path))
+        entry = {
+            "statement_id": header.get("statement_id", path.stem),
+            "statement": event.get("statement", ""),
+            "header": header_b64,
+            "microblock_size": microblock_size,
+            "microblock_count": block_count,
+            "mined_blocks": mined_blocks,
+            "unmined_blocks": unmined_blocks,
+            "submitted_at": submitted_at,
+            "wallet_id": event.get("originator_pub"),
+            "finalized": False,
+        }
+        entries.append((submitted_at, entry))
+
+    entries.sort(key=lambda x: x[0], reverse=True)
+    return [e for _, e in entries]
 
 
 @app.get("/api/events")


### PR DESCRIPTION
## Summary
- enable CORS for dashboard backend
- provide `/api/statements/active_status` to inspect active statements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_6865b549d6a083298ee39f8daceceae9