### PR TITLE
Add bet status FastAPI route

### DIFF
--- a/dashboard/backend/main.py
+++ b/dashboard/backend/main.py
@@ -12,6 +12,7 @@ from helix.event_manager import (
     save_event,
     load_event,
     list_events as list_saved_events,
+    get_bets_for_event,
 )
 from helix.utils import compression_ratio
 
@@ -97,6 +98,29 @@ async def get_statement(statement_id: str) -> dict:
         return json.loads(path.read_text())
     except Exception as exc:  # pragma: no cover - invalid file
         raise HTTPException(status_code=500, detail=str(exc))
+
+
+@app.get("/api/bets/status/{statement_id}")
+async def bet_status(statement_id: str) -> dict:
+    """Return total HLX bet on TRUE and FALSE for ``statement_id``."""
+    path = EVENTS_DIR / f"{statement_id}.json"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Statement not found")
+
+    try:
+        event = load_event(str(path))
+    except Exception as exc:  # pragma: no cover - invalid file
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    yes_bets, no_bets = get_bets_for_event(event)
+    total_true = sum(float(b.get("amount", 0)) for b in yes_bets)
+    total_false = sum(float(b.get("amount", 0)) for b in no_bets)
+
+    return {
+        "statement_id": statement_id,
+        "total_true_bets": total_true,
+        "total_false_bets": total_false,
+    }
 
 
 @app.post("/api/submit")

--- a/tests/test_api_bets_status.py
+++ b/tests/test_api_bets_status.py
@@ -1,0 +1,39 @@
+from fastapi.testclient import TestClient
+
+from dashboard.backend import main
+from helix import event_manager, betting_interface, signature_utils
+
+
+def test_bet_status_endpoint(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(main, "EVENTS_DIR", tmp_path)
+
+    client = TestClient(main.app)
+
+    event = event_manager.create_event("bet test", microblock_size=2)
+    evt_id = event["header"]["statement_id"]
+
+    # create YES bet
+    pub1, priv1 = signature_utils.generate_keypair()
+    kf1 = tmp_path / "w1.txt"
+    signature_utils.save_keys(str(kf1), pub1, priv1)
+    bet1 = betting_interface.submit_bet(evt_id, "YES", 5, str(kf1))
+    betting_interface.record_bet(event, bet1)
+
+    # create NO bet
+    pub2, priv2 = signature_utils.generate_keypair()
+    kf2 = tmp_path / "w2.txt"
+    signature_utils.save_keys(str(kf2), pub2, priv2)
+    bet2 = betting_interface.submit_bet(evt_id, "NO", 3, str(kf2))
+    betting_interface.record_bet(event, bet2)
+
+    event_manager.save_event(event, str(tmp_path))
+
+    res = client.get(f"/api/bets/status/{evt_id}")
+    assert res.status_code == 200
+    data = res.json()
+    assert data == {
+        "statement_id": evt_id,
+        "total_true_bets": 5.0,
+        "total_false_bets": 3.0,
+    }


### PR DESCRIPTION
## Summary
- add `get_bets_for_event` import
- implement `/api/bets/status/{statement_id}` endpoint
- add test for the new endpoint

## Testing
- `pytest -q tests/test_api_bets_status.py`

------
https://chatgpt.com/codex/tasks/task_e_6865b578e5a88329b4f0c264b71bb797