### PR TITLE
Implement finalized statements history API

### DIFF
--- a/tests/test_history_api.py
+++ b/tests/test_history_api.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+from fastapi.testclient import TestClient
+from dashboard.backend import main
+
+
+def test_statement_history_endpoint(tmp_path, monkeypatch):
+    finalized = tmp_path / "finalized.jsonl"
+    events_dir = tmp_path / "events"
+    events_dir.mkdir()
+
+    event = {
+        "header": {"statement_id": "abc", "microblock_size": 2, "block_count": 1},
+        "statement": "hello",
+        "microblocks": ["6869"],
+        "seeds": ["aa"],
+        "miners": ["m1"],
+        "is_closed": True,
+        "finalized": True,
+    }
+    (events_dir / "abc.json").write_text(json.dumps(event))
+
+    entry = {
+        "statement_id": "abc",
+        "statement": "hello",
+        "previous_hash": "00",
+        "delta_seconds": 1.0,
+        "seeds": ["aa"],
+        "miners": ["m1"],
+        "timestamp": 10.0,
+    }
+    finalized.write_text(json.dumps(entry) + "\n")
+
+    monkeypatch.setattr(main, "FINALIZED_FILE", finalized)
+    monkeypatch.setattr(main, "EVENTS_DIR", events_dir)
+
+    client = TestClient(main.app)
+    resp = client.get("/api/statements/history")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    rec = data[0]
+    assert rec["finalized"] is True
+    assert rec["statement_id"] == "abc"
+    assert rec["timestamp"] == 10.0
+    assert rec["statement"] == "hello"
+    assert rec["seeds"] == ["aa"]
+    assert "compression_ratio" in rec


### PR DESCRIPTION
## Summary
- expose `/api/statements/history` for finalized statements
- convert seeds to hex for JSON output
- test new history endpoint

## Testing
- `pytest tests/test_history_api.py -vv`
- `./run_tests.sh` *(fails: 7 failed, 67 passed, 32 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6865b58a2fec8329ac1e48463275e55c