### PR TITLE
Fix balance endpoint to use balances.json

### DIFF
--- a/dashboard/backend/main.py
+++ b/dashboard/backend/main.py
@@ -120,7 +120,7 @@ async def submit_statement(req: SubmitRequest) -> dict:
 @app.get("/api/balance/{wallet_id}")
 async def wallet_balance(wallet_id: str) -> dict:
     """Return HLX balance for ``wallet_id``."""
-    balances = load_balances("wallet.json")
+    balances = load_balances("balances.json")
     balance = balances.get(wallet_id)
     if balance is None:
         raise HTTPException(status_code=404, detail="Wallet not found")


### PR DESCRIPTION
## Summary
- adjust wallet balance route to read from `balances.json`

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865b95138348329a0afde7fd7d934df