### PR TITLE
Disable gas cost in mining rewards

### DIFF
--- a/helix/ledger.py
+++ b/helix/ledger.py
@@ -59,6 +59,22 @@ def save_balances(balances: Dict[str, float], path: str) -> None:
         json.dump(balances, fh, indent=2)
 
 
+def apply_mining_reward(wallet_id: str, block_count: int, path: str = "balances.json") -> None:
+    """Credit ``wallet_id`` with mining rewards for ``block_count`` blocks.
+
+    Gas costs are disabled for testing, so the wallet balance only increases
+    by the reward amount.  The reward remains ``1`` HLX per mined block.
+    """
+    balances = load_balances(path)
+    reward = block_count  # still reward 1 HLX per block
+    gas_cost = 0  # disable gas entirely for testing
+
+    balances[wallet_id] = balances.get(wallet_id, 0) + reward
+
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(balances, f, indent=2)
+
+
 def log_ledger_event(
     action: str,
     wallet: str,
@@ -258,6 +274,7 @@ def apply_mining_results(
 __all__ = [
     "load_balances",
     "save_balances",
+    "apply_mining_reward",
     "log_ledger_event",
     "apply_delta_bonus",
     "apply_delta_penalty",


### PR DESCRIPTION
## Summary
- add `apply_mining_reward` helper in `helix/ledger.py`
- export `apply_mining_reward`

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'nacl' before installing deps; other tests failing after installing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6865b95c04248329876a059b41b79b21