### PR TITLE
Add GUI launch script

### DIFF
--- a/launch_helix_gui.bat
+++ b/launch_helix_gui.bat
@@ -1,10 +1,18 @@
 @echo off
-setlocal
+cd /d %~dp0
 
-rem Start the backend
-start cmd /k "cd /d %CD% && uvicorn dashboard.backend.main:app --reload --port 8000"
+REM Activate Python venv and start backend
+if exist venv\Scripts\activate.bat (
+    start cmd /k "cd /d %~dp0 && call venv\Scripts\activate.bat && uvicorn dashboard.backend.main:app --reload"
+) else (
+    echo [!] Python virtual environment not found. Please run setup manually.
+)
 
-rem Start the frontend
-start cmd /k "cd /d %CD%\dashboard\frontend && npm start"
-
-endlocal
+REM Start frontend
+cd dashboard\frontend
+if not exist node_modules (
+    echo Installing missing Node packages...
+    npm install axios react-router-dom
+    npm install
+)
+start cmd /k "cd /d %cd% && npm start"


### PR DESCRIPTION
## Summary
- improve launch_helix_gui.bat to activate venv, start backend, and check Node dependencies
- use `start cmd` to run backend and frontend concurrently

## Testing
- `./run_tests.sh` *(fails: 9 failed, 66 passed, 32 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6865ce0fced48329a7ff8946ae9a9be6