### PR TITLE
Update pending statement encoding

### DIFF
--- a/helix/helix_node.py
+++ b/helix/helix_node.py
@@ -278,6 +278,17 @@ class HelixNode(GossipNode):
         self.events[evt_id] = event
         return event
 
+    def mine_event(self, event: Dict[str, Any]) -> None:
+        """Mine microblocks for ``event`` using :func:`find_seed`."""
+
+        for idx, block in enumerate(event.get("microblocks", [])):
+            if event.get("seeds", [None])[idx] is not None:
+                continue
+            seed = find_seed(block)
+            if seed is None:
+                continue
+            event_manager.accept_mined_seed(event, idx, [seed], miner=self.node_id)
+
     def import_event(self, event: Dict[str, Any]) -> None:
         """Validate and store ``event`` in the node state."""
 

--- a/tests/test_single_node_microblock.py
+++ b/tests/test_single_node_microblock.py
@@ -34,7 +34,9 @@ def test_single_node_microblock(tmp_path, monkeypatch, capsys):
     node.events[evt_id] = event
     node.save_state()
 
-    node.send_message({"type": GossipMessageType.NEW_STATEMENT, "event": event})
+    send_event = event.copy()
+    send_event["microblocks"] = [b.hex() for b in send_event["microblocks"]]
+    node.send_message({"type": GossipMessageType.NEW_STATEMENT, "event": send_event})
     node.mine_event(event)
     time.sleep(0.1)
 


### PR DESCRIPTION
## Summary
- encode pending statements with header + payload
- add `/api/pending` route for microblock details
- expose simple mining helper on `HelixNode`
- adjust single node microblock test

## Testing
- `pytest tests/test_full_statement_lifecycle.py::test_full_statement_lifecycle -q`
- `pytest tests/test_single_node_microblock.py::test_single_node_microblock -q`
- `pytest -q` *(fails: TypeError & assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866d6e324648329b6e64abfcd1e9218