### PR TITLE
Update Dice Roller UI and add /api/generate

### DIFF
--- a/dashboard/backend/main.py
+++ b/dashboard/backend/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import base64
+import hashlib
 import math
 import time
 from pathlib import Path
@@ -47,6 +48,9 @@ class SubmitRequest(BaseModel):
     statement: str
     wallet_id: str
     microblock_size: int = 3
+
+class GenerateRequest(BaseModel):
+    seed: str
 
 @app.post("/api/submit")
 async def submit_statement(req: SubmitRequest) -> dict:
@@ -289,6 +293,14 @@ async def bet_status(statement_id: str) -> dict:
         "total_true_bets": total_true,
         "total_false_bets": total_false,
     }
+
+
+@app.post("/api/generate")
+async def generate(req: GenerateRequest) -> dict:
+    """Return deterministic output for provided seed."""
+    seed_bytes = req.seed.encode("utf-8")
+    out = hashlib.sha256(seed_bytes).hexdigest()[:16]
+    return {"output": out}
 
 @app.get("/api/balance/{wallet_id}")
 async def wallet_balance(wallet_id: str) -> dict:

--- a/dashboard/frontend/src/components/DiceRoller.jsx
+++ b/dashboard/frontend/src/components/DiceRoller.jsx
@@ -3,22 +3,17 @@ import axios from "axios";
 
 export default function DiceRoller() {
   const [seed, setSeed] = useState("");
-  const [size, setSize] = useState(6);
+  const [size, setSize] = useState(0);
   const [output, setOutput] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
   const roll = () => {
-    const sz = Number(size);
-    if (isNaN(sz) || sz < 1 || sz > 32) {
-      setError("Size must be between 1 and 32");
-      return;
-    }
     setLoading(true);
     setError("");
     setOutput("");
     axios
-      .post("/api/generate", { seed, size: sz })
+      .post("/api/generate", { seed })
       .then((res) => {
         if (res.data && res.data.output) {
           setOutput(res.data.output);
@@ -45,20 +40,20 @@ export default function DiceRoller() {
       <label className="text-sm font-medium">Size</label>
       <input
         type="number"
-        min="1"
-        max="32"
+        min="0"
         className="border p-1 mb-2 w-full"
         value={size}
         onChange={(e) => setSize(e.target.value)}
       />
       <button onClick={roll} className="mx-auto mb-2">
-        <img src="/helix_icon.ico" alt="roll" className="w-8 h-8" />
+        <img src="/helix_icon.ico" alt="roll" className="w-6 h-6" />
       </button>
       {loading && <div className="text-sm">Loading...</div>}
       {error && <div className="text-sm text-red-600">{error}</div>}
       {output && (
-        <pre className="mt-2 bg-gray-100 p-2 overflow-auto font-mono break-all">
-          {output}
+        <pre className="mt-2 font-mono flex">
+          <span style={{ color: "#00AEEF" }}>{output.slice(0, Number(size))}</span>
+          <span>{output.slice(Number(size))}</span>
         </pre>
       )}
     </div>


### PR DESCRIPTION
## Summary
- shrink the Helix icon
- highlight deterministic output from `/api/generate`
- adjust size input behavior
- implement `/api/generate` endpoint in FastAPI backend

## Testing
- `./run_tests.sh` *(fails: 11 errors, 23 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6866f56a6f4c83298c1de46ba6209cbd