### PR TITLE
Fix Helix GUI launch script

### DIFF
--- a/launch_helix_gui.bat
+++ b/launch_helix_gui.bat
@@ -1,10 +1,10 @@
 @echo off
 echo Starting Helix frontend and backend...
 
-:: Backend server
-start cmd /k "cd /d C:\Users\93rob\OneDrive\Documents\GitHub\helix-protocol && uvicorn dashboard.backend.main:app --reload"
+:: Start backend with virtualenv activated
+start cmd /k "cd /d C:\Users\93rob\OneDrive\Documents\GitHub\helix-protocol && call venv\Scripts\activate && uvicorn dashboard.backend.main:app --reload"
 
-:: Frontend client
+:: Prepare frontend
 cd /d C:\Users\93rob\OneDrive\Documents\GitHub\helix-protocol\dashboard\frontend
 echo Installing frontend dependencies...
 call npm install


### PR DESCRIPTION
## Summary
- activate virtual environment before starting backend
- keep frontend dependency install step

## Testing
- `pip install -q -r requirements.txt` *(fails: ModuleNotFoundError due to network restrictions)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686704f50d088329a4d7c4f342e30c5e